### PR TITLE
Fix History.getmaxset

### DIFF
--- a/src/models/history.ts
+++ b/src/models/history.ts
@@ -38,7 +38,13 @@ export namespace History {
   export function getMaxSet(entry: IHistoryEntry): ISet | undefined {
     return CollectionUtils.sort(
       entry.sets.filter((s) => (s.completedReps || 0) > 0),
-      (a, b) => Weight.compare(b.weight, a.weight)
+      (a, b) => {
+        const weightDiff = Weight.compare(b.weight, a.weight);
+        if (weightDiff === 0 && a.completedReps && b.completedReps) {
+          return b.completedReps - a.completedReps;
+        }
+        return weightDiff;
+      }
     )[0];
   }
 

--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -1,0 +1,34 @@
+import { History } from "../src/models/history";
+import { IHistoryEntry } from "../src/types";
+
+describe("History", () => {
+  describe(".getMaxSet()", () => {
+    it("returns the set with the highest completed reps", () => {
+      const entry: IHistoryEntry = {
+        exercise: { id: 'squat'},
+        sets: [
+          {
+            reps: 10,
+            completedReps: 10,
+            weight: { value: 10, unit: "kg"}
+          },
+          {
+            reps: 5,
+            completedReps: 5,
+            weight: { value: 50, unit: "kg"}
+          },
+          {
+            reps: 5,
+            completedReps: 6,
+            isAmrap: true,
+            weight: { value: 50, unit: "kg"}
+          }
+        ],
+        warmupSets: [],
+      }
+      const maxSet = History.getMaxSet(entry)
+      expect(maxSet?.weight.value).toEqual(50);
+      expect(maxSet?.completedReps).toEqual(6);
+    });
+  });
+});


### PR DESCRIPTION
Hi there :)
Thanks heaps for this app!
I've started to use it and I am keen to help improve it even further.
My javascript is rusty so I would appreciate your review.

I noticed that when making personal records, the number of reps displayed did not match the true highest reps performed with that weight (e.g. with an AMRAP set).

Example:
<img width="181" alt="Screenshot 2022-01-21 at 3 46 43 pm" src="https://user-images.githubusercontent.com/98141373/150470292-3468f6aa-5437-49cf-b7a0-10c9935a708d.png">
I was expecting the PR to be "10x45 lb" but instead:
<img width="235" alt="Screenshot 2022-01-21 at 4 14 13 pm" src="https://user-images.githubusercontent.com/98141373/150470303-50d12160-1a44-4478-99e4-4d384bbbec57.png">

I've tracked down the logic to `History.getMaxSet` and added logic to compare 2 sets using the completedReps when the weights are the same. I've also added a small unit test covering this use case.
Results:
<img width="217" alt="Screenshot 2022-01-21 at 3 46 49 pm" src="https://user-images.githubusercontent.com/98141373/150470382-cc6395ef-7961-425e-89e9-59e4ecd169cd.png">

