### PR TITLE
Fix Pec Deck used muscles

### DIFF
--- a/src/models/exercise.ts
+++ b/src/models/exercise.ts
@@ -2158,8 +2158,8 @@ const metadata: Record<IExerciseId, Partial<Record<IEquipment, IMetaExercises>>>
   },
   pecDeck: {
     leverageMachine: {
-       targetMuscles: ["Pectoralis Major Sternal Head"],
-       synergistMuscles: ["Pectoralis Major Clavicular Head", "Serratus Anterior"]
+      targetMuscles: ["Pectoralis Major Sternal Head"],
+      synergistMuscles: ["Pectoralis Major Clavicular Head", "Serratus Anterior"],
       bodyParts: ["Chest"],
     },
   },

--- a/src/models/exercise.ts
+++ b/src/models/exercise.ts
@@ -2158,8 +2158,8 @@ const metadata: Record<IExerciseId, Partial<Record<IEquipment, IMetaExercises>>>
   },
   pecDeck: {
     leverageMachine: {
-       "targetMuscles": ["Pectoralis Major Sternal Head"],
-        "synergistMuscles": ["Pectoralis Major Clavicular Head", "Serratus Anterior"]
+       targetMuscles: ["Pectoralis Major Sternal Head"],
+       synergistMuscles: ["Pectoralis Major Clavicular Head", "Serratus Anterior"]
       bodyParts: ["Chest"],
     },
   },

--- a/src/models/exercise.ts
+++ b/src/models/exercise.ts
@@ -2158,8 +2158,8 @@ const metadata: Record<IExerciseId, Partial<Record<IEquipment, IMetaExercises>>>
   },
   pecDeck: {
     leverageMachine: {
-      targetMuscles: ["Biceps Brachii"],
-      synergistMuscles: ["Brachialis", "Brachioradialis"],
+       "targetMuscles": ["Pectoralis Major Sternal Head"],
+        "synergistMuscles": ["Pectoralis Major Clavicular Head", "Serratus Anterior"]
       bodyParts: ["Chest"],
     },
   },


### PR DESCRIPTION
The Pec Deck exercise had the muscle definitions of what seems to be some curl (if it didn't isolate the Pectoralis, why would it be named Pec Deck?)

