### PR TITLE
Measurement Graph Locker

### DIFF
--- a/src/components/statsList.tsx
+++ b/src/components/statsList.tsx
@@ -103,19 +103,21 @@ export function StatsList(props: IProps): JSX.Element {
         }}
       />
       <div className="relative">
-        <Locker topic="Graphs" dispatch={props.dispatch} blur={8} subscription={props.subscription} />
         {graphPoints.length > 2 && (
-          <GraphStats
-            title={null}
-            isSameXAxis={false}
-            minX={graphPoints[0][0]}
-            maxX={graphPoints[graphPoints.length - 1][0]}
-            units={graphUnit}
-            key={selectedKey}
-            settings={props.settings}
-            collection={graphPoints}
-            statsKey={selectedKey}
-          />
+          <>
+            <GraphStats
+              title={null}
+              isSameXAxis={false}
+              minX={graphPoints[0][0]}
+              maxX={graphPoints[graphPoints.length - 1][0]}
+              units={graphUnit}
+              key={selectedKey}
+              settings={props.settings}
+              collection={graphPoints}
+              statsKey={selectedKey}
+            />
+            <Locker topic="Graphs" dispatch={props.dispatch} blur={8} subscription={props.subscription} />
+          </>
         )}
       </div>
       {values.length === 0 ? (


### PR DESCRIPTION
When there are not enough datapoints no graph is shown, which causes the locker to appear above the type select and messes with the layout.