### PR TITLE
Use sets x reps as requested on #49

### DIFF
--- a/src/components/historyRecordSets.tsx
+++ b/src/components/historyRecordSets.tsx
@@ -78,8 +78,8 @@ export function HistoryRecordSet(props: { sets: IDisplaySet[]; isNext: boolean }
           }
           className="pb-1 font-bold border-b border-grayv2-200"
         >
+          {length > 1 && <span className="text-sm text-purplev2-main">{length}x</span>}
           <span className={`${color} text-lg`}>{set.reps}</span>
-          {length > 1 && <span className="text-sm text-purplev2-main">x{length}</span>}
         </div>
         <div data-cy="history-entry-weight" className="pt-2 text-sm font-bold text-grayv2-main">
           {set.weight}


### PR DESCRIPTION
Hi! I'm not sure if you're accepting these types of changes as PRs but as requested on #49 I switched the order of the reps/sets to the more generally used {sets}x{reps}. I have to agree with them that the current order is a bit confusing sometimes.

It looks like this:
![20230701](https://github.com/astashov/liftosaur/assets/106948293/ddecc63f-0a60-42f6-98bb-6980f27daa3c)

Feel free to ignore this PR if this is something you'd rather change later on (or not change it at all :D)

I'm not sure if the sets/reps show up on some of the premium pages, I don't have access to those. If they do let me know and I'll try to dig some more through the files and change it there too.