### PR TITLE
Use sets for congrats screen muscle groups

### DIFF
--- a/src/components/screenFinishDay.tsx
+++ b/src/components/screenFinishDay.tsx
@@ -41,7 +41,6 @@ export function ScreenFinishDay(props: IProps): JSX.Element {
 
   const historyCollector = Collector.build([record]).addFn(History.collectMuscleGroups(props.settings));
   const [muscleGroupsData] = historyCollector.run();
-  console.log(muscleGroupsData); // FIXME: remove!
 
   return (
     <Surface

--- a/src/components/screenFinishDay.tsx
+++ b/src/components/screenFinishDay.tsx
@@ -41,6 +41,7 @@ export function ScreenFinishDay(props: IProps): JSX.Element {
 
   const historyCollector = Collector.build([record]).addFn(History.collectMuscleGroups(props.settings));
   const [muscleGroupsData] = historyCollector.run();
+  console.log(muscleGroupsData); // FIXME: remove!
 
   return (
     <Surface
@@ -81,29 +82,25 @@ export function ScreenFinishDay(props: IProps): JSX.Element {
             Total reps: <strong>{totalReps}</strong>
           </div>
         </section>
-        <div className="mt-4 text-sm font-bold text-center">Volume per muscle group</div>
+        <div className="mt-4 text-sm font-bold text-center">Sets per muscle group</div>
         <div className="flex mt-1" style={{ gap: "1rem" }}>
           <ul className="flex-1">
             {leftColumn
-              .filter((c) => muscleGroupsData[c][1][0] > 0)
+              .filter((c) => muscleGroupsData[c][2][0] > 0)
               .map((muscle) => (
                 <li>
                   <span className="text-grayv2-main">{StringUtils.capitalize(muscle)}</span>:{" "}
-                  <strong>
-                    {muscleGroupsData[muscle][1] || 0} {props.settings.units}
-                  </strong>
+                  <strong>{muscleGroupsData[muscle][2] || 0}</strong>
                 </li>
               ))}
           </ul>
           <ul className="flex-1">
             {rightColumn
-              .filter((c) => muscleGroupsData[c][1][0] > 0)
+              .filter((c) => muscleGroupsData[c][2][0] > 0)
               .map((muscle) => (
                 <li>
                   <span className="text-grayv2-main">{StringUtils.capitalize(muscle)}</span>:{" "}
-                  <strong>
-                    {muscleGroupsData[muscle][1] || 0} {props.settings.units}
-                  </strong>
+                  <strong>{muscleGroupsData[muscle][2] || 0}</strong>
                 </li>
               ))}
           </ul>


### PR DESCRIPTION
This change uses sets instead of volumes for muscle groups in the "congrats"
screen after finishing a workout. Screenshot:

![image](https://github.com/astashov/liftosaur/assets/7947900/4315a057-01b1-4f3b-9dc3-2139f082abc6)

See [Discord conversation](https://discord.com/channels/1086086904124014723/1086086905113886742/1143498517701202040).
