### PR TITLE
Fix rounding in edit set modal

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,6 @@
 - Move the app from liftosaur.com to liftosaur.com/app
 - Add calculate1RM function
 - Add integration with Apple Health
-- Fix the bug with rounding when editing the set
 - Fix the bug with clipboard in Safari
 
 * Programs

--- a/src/components/modalEditSet.tsx
+++ b/src/components/modalEditSet.tsx
@@ -113,7 +113,12 @@ export function ModalEditSet(props: IModalWeightProps): JSX.Element {
                 }
               }}
               // @ts-ignore
-              defaultValue={initialWeight}
+              defaultValue={
+                Weight.round(
+                  Weight.build(initialWeight || 0, props.settings.units), 
+                  props.settings, props.equipment
+                ).value
+              }
               required
               type={SendMessage.isIos() ? "number" : "tel"}
               step="0.05"


### PR DESCRIPTION
This prevents ugly long numbers in the edit set modal window:

![image](https://github.com/astashov/liftosaur/assets/7266447/5c46035b-832f-41b7-82a4-e0541bafb4ff)

Rounds to the available equipment.