### PR TITLE
Fix wrong keyboard and hard-coded unit of weights

### DIFF
--- a/src/components/modalWeight.tsx
+++ b/src/components/modalWeight.tsx
@@ -6,6 +6,7 @@ import { Button } from "./button";
 import { Weight } from "../models/weight";
 import { IProgramExercise, IUnit, IWeight } from "../types";
 import { GroupHeader } from "./groupHeader";
+import { SendMessage } from "../utils/sendMessage";
 
 interface IModalWeightProps {
   dispatch: IDispatch;
@@ -35,9 +36,9 @@ export function ModalWeight(props: IModalWeightProps): JSX.Element {
           data-cy="modal-weight-input"
           className="block w-full px-4 py-2 text-base leading-normal bg-white border border-gray-300 rounded-lg appearance-none focus:outline-none focus:shadow-outline"
           value={Weight.is(props.weight) ? props.weight.value : props.weight}
-          type="tel"
+          type={SendMessage.isIos() ? "number" : "tel"}
           min="0"
-          placeholder="Weight in lbs"
+          placeholder={`Weight in ${props.units}`}
         />
         <div className="mt-4 text-right">
           <Button


### PR DESCRIPTION
This fixes the wrong keyboard on iOS when changing weights during a workout and removes the hard-coded weight unit that is present in the placeholder:

Previously:
![IMG_4245](https://github.com/astashov/liftosaur/assets/7266447/191c1a03-4e24-44f6-88f7-fc41b606756b)
