### PR TITLE
Feature: Moving averages on graphs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 - Push notif for the forgotten session
 - AMRAP as an expression
 - Dynamic sets!
-- Moving average on graphs
 - Use state vars for warmups
 - Add negative indexing (-1)
 - Names for variation sets

--- a/src/components/graphStats.tsx
+++ b/src/components/graphStats.tsx
@@ -55,7 +55,7 @@ export function GraphStats(props: IGraphStatsProps): JSX.Element {
   const graphRef = useRef<HTMLDivElement>(null);
   const legendRef = useRef<HTMLDivElement>(null);
   const useMovingAverage: boolean = props.movingAverageWindowSize !== undefined;
-  const avgWindowSize = props.movingAverageWindowSize || 3;
+  const avgWindowSize = props.movingAverageWindowSize || 5;
   useEffect(() => {
     const data = props.collection.reduce<[number[], number[], number[]]>(
       (memo, i, index, array) => {
@@ -95,12 +95,11 @@ export function GraphStats(props: IGraphStatsProps): JSX.Element {
                 const idx = self.cursor.idx!;
                 const date = new Date(data[0][idx] * 1000);
                 const value = data[1][idx];
-                const avg = data[2][idx];
                 let text: string;
                 if (value != null && props.units != null) {
                   text = `${DateUtils.format(date)}, <strong>${value}</strong> ${props.units}`;
                   if (useMovingAverage) {
-                    text += ` (Avg. ${avg} ${props.units})`;
+                    text += ` (Avg. ${data[2][idx]} ${props.units})`;
                   }
                 } else {
                   text = "";

--- a/src/components/graphStats.tsx
+++ b/src/components/graphStats.tsx
@@ -27,6 +27,7 @@ interface IGraphStatsProps {
   isSameXAxis?: boolean;
   minX: number;
   maxX: number;
+  movingAverageWindowSize?: number;
 }
 
 export function getWeightDataForGraph(coll: IStatsWeightValue[], settings: ISettings): [number, number][] {
@@ -53,14 +54,27 @@ export function getPercentageDataForGraph(coll: IStatsPercentageValue[], setting
 export function GraphStats(props: IGraphStatsProps): JSX.Element {
   const graphRef = useRef<HTMLDivElement>(null);
   const legendRef = useRef<HTMLDivElement>(null);
+  const useMovingAverage: boolean = props.movingAverageWindowSize !== undefined;
+  const avgWindowSize = props.movingAverageWindowSize || 3;
   useEffect(() => {
-    const data = props.collection.reduce<[number[], number[]]>(
-      (memo, i) => {
+    const data = props.collection.reduce<[number[], number[], number[]]>(
+      (memo, i, index, array) => {
         memo[0].push(i[0]);
         memo[1].push(i[1]);
+
+        if (useMovingAverage) {
+          if (index >= avgWindowSize - 1) {
+            const movingAvg =
+              memo[1].slice(index - avgWindowSize + 1, index + 1).reduce((a, b) => a + b, 0) / avgWindowSize;
+            memo[2].push(Math.round(movingAvg * 10) / 10);
+          } else {
+            memo[2].push(i[1]);
+          }
+        }
+
         return memo;
       },
-      [[], []]
+      [[], [], []]
     );
     const rect = graphRef.current.getBoundingClientRect();
     const opts: UPlot.Options = {
@@ -81,9 +95,13 @@ export function GraphStats(props: IGraphStatsProps): JSX.Element {
                 const idx = self.cursor.idx!;
                 const date = new Date(data[0][idx] * 1000);
                 const value = data[1][idx];
+                const avg = data[2][idx];
                 let text: string;
                 if (value != null && props.units != null) {
                   text = `${DateUtils.format(date)}, <strong>${value}</strong> ${props.units}`;
+                  if (useMovingAverage) {
+                    text += ` (Avg. ${avg} ${props.units})`;
+                  }
                 } else {
                   text = "";
                 }
@@ -107,6 +125,14 @@ export function GraphStats(props: IGraphStatsProps): JSX.Element {
           stroke: "red",
           width: 1,
         },
+        useMovingAverage
+          ? {
+              label: "Moving Average",
+              value: (self, rawValue) => `${rawValue} ${props.units}`,
+              stroke: "blue",
+              width: 1,
+            }
+          : {},
       ],
     };
 

--- a/src/components/statsList.tsx
+++ b/src/components/statsList.tsx
@@ -59,6 +59,8 @@ export function StatsList(props: IProps): JSX.Element {
     ...ObjectUtils.keys(props.stats.length),
   ];
   const [selectedKey, setSelectedKey] = useState<IStatsKey>(statsKeys[0] || "weight");
+  const [averageWindowSize, setAverageWindowSize] = useState("5");
+  const [graphState, setGraphState] = useState([selectedKey, averageWindowSize]);
   const values = getValues(props.stats, selectedKey);
 
   if (statsKeys.length === 0) {
@@ -100,6 +102,23 @@ export function StatsList(props: IProps): JSX.Element {
         values={statsKeys.map((key) => [key, Stats.name(key)])}
         onChange={(value) => {
           setSelectedKey(value as IStatsKey);
+          setGraphState([selectedKey, averageWindowSize]);
+        }}
+      />
+      <MenuItemEditable
+        name="Moving Average Data Points"
+        type="select"
+        value={averageWindowSize.toString()}
+        values={[
+          ["off", "Off"],
+          ["2", "2"],
+          ["3", "3"],
+          ["4", "4"],
+          ["5", "5"],
+        ]}
+        onChange={(value) => {
+          setAverageWindowSize(value || "off");
+          setGraphState([selectedKey, averageWindowSize]);
         }}
       />
       <div className="relative">
@@ -111,10 +130,11 @@ export function StatsList(props: IProps): JSX.Element {
               minX={graphPoints[0][0]}
               maxX={graphPoints[graphPoints.length - 1][0]}
               units={graphUnit}
-              key={selectedKey}
+              key={graphState}
               settings={props.settings}
               collection={graphPoints}
               statsKey={selectedKey}
+              movingAverageWindowSize={averageWindowSize === "off" ? undefined : Number(averageWindowSize)}
             />
             <Locker topic="Graphs" dispatch={props.dispatch} blur={8} subscription={props.subscription} />
           </>


### PR DESCRIPTION
This PR adds moving averages to the graphs in the "Measurements" section. The window size for which the average will be computed can be set by the user:

<img width="829" alt="CleanShot 2023-09-20 at 21 29 49@2x" src="https://github.com/astashov/liftosaur/assets/7266447/a73fe09b-3e51-465f-a61f-86a555fced11">

It can also be turned off when selecting the "Off" option in the window size.