### PR TITLE
Adapt plate calculations to find the nearest set of plates.

### DIFF
--- a/src/models/weight.ts
+++ b/src/models/weight.ts
@@ -249,7 +249,7 @@ export namespace Weight {
     let exactMatchFound = false;
 
     function backtrack(index: number, remainingWeight: IWeight, currentResult: IPlate[]): void {
-      if (Weight.lt(remainingWeight, 0) || exactMatchFound) {
+      if (exactMatchFound) {
         return;
       }
 
@@ -259,7 +259,14 @@ export namespace Weight {
         return;
       }
 
-      if (Weight.lt(remainingWeight, closestWeightDifference)) {
+      if (Weight.lt(remainingWeight, 0)) {
+        const negRemainingWeight = Weight.build(-remainingWeight.value, remainingWeight.unit);
+        if (Weight.lt(negRemainingWeight, closestWeightDifference)) {
+          closestWeightDifference = negRemainingWeight
+          result = currentResult.map((plate) => ({ ...plate }));
+        }
+        return;
+      } else if (Weight.lt(remainingWeight, closestWeightDifference)) {
         closestWeightDifference = remainingWeight;
         result = currentResult.map((plate) => ({ ...plate }));
       }

--- a/test/weight.test.ts
+++ b/test/weight.test.ts
@@ -125,6 +125,59 @@ describe("Weight", () => {
         { weight: Weight.build(45, "lb"), num: 4 },
       ]);
     });
+
+    it("backtrack method prefers low plate counts, example rounding up", () => {
+      const settings = buildSettings([
+        { weight: Weight.build(20, "lb"), num: 4 },
+        { weight: Weight.build(10, "lb"), num: 4 },
+        { weight: Weight.build(5, "lb"), num: 4 },
+        { weight: Weight.build(2.5, "lb"), num: 4 },
+      ]);
+      const result = Weight.calculatePlates(Weight.build(62.5, "lb"), settings, exerciseType).plates;
+      expect(result).to.eql([
+        { weight: { value: 10, unit: "lb" }, num: 2 },
+      ]);
+    });
+
+    it("backtrack method prefers low plate counts, example rounding down", () => {
+      const settings = buildSettings([
+        { weight: Weight.build(20, "lb"), num: 4 },
+        { weight: Weight.build(10, "lb"), num: 4 },
+        { weight: Weight.build(5, "lb"), num: 4 },
+        { weight: Weight.build(2.5, "lb"), num: 4 },
+      ]);
+      const result = Weight.calculatePlates(Weight.build(67.5, "lb"), settings, exerciseType).plates;
+      expect(result).to.eql([
+        { weight: { value: 10, unit: "lb" }, num: 2 },
+      ]);
+    });
+
+    it("greedy method returns the first solution, always rounding down", () => {
+      const settings = buildSettings([
+        { weight: Weight.build(20, "lb"), num: 400 },
+        { weight: Weight.build(10, "lb"), num: 4 },
+        { weight: Weight.build(5, "lb"), num: 4 },
+        { weight: Weight.build(2.5, "lb"), num: 4 },
+      ]);
+      const result = Weight.calculatePlates(Weight.build(62.5, "lb"), settings, exerciseType).plates;
+      expect(result).to.eql([
+        { weight: { value: 5, unit: "lb" }, num: 2 },
+        { weight: { value: 2.5, unit: "lb" }, num: 2 },
+      ]);
+    });
+
+    it("greedy method example adding small plates and then removing them", () => {
+      const settings = buildSettings([
+        { weight: Weight.build(20, "lb"), num: 400 },
+        { weight: Weight.build(10, "lb"), num: 4 },
+        { weight: Weight.build(5, "lb"), num: 4 },
+        { weight: Weight.build(2.5, "lb"), num: 2 },
+      ]);
+      const result = Weight.calculatePlates(Weight.build(63.5, "lb"), settings, exerciseType).plates;
+      expect(result).to.eql([
+        { weight: { value: 10, unit: "lb" }, num: 2 },
+      ]);
+    });
   });
 
   describe(".platesWeight()", () => {

--- a/test/weight.test.ts
+++ b/test/weight.test.ts
@@ -93,6 +93,7 @@ describe("Weight", () => {
         { weight: { value: 5, unit: "lb" }, num: 2 },
         { weight: { value: 3, unit: "lb" }, num: 2 },
         { weight: { value: 0.5, unit: "lb" }, num: 2 },
+        { weight: { value: 0.25, unit: "lb" }, num: 2 },
       ]);
     });
 

--- a/test/weight.test.ts
+++ b/test/weight.test.ts
@@ -122,9 +122,7 @@ describe("Weight", () => {
       ]);
       const result = Weight.calculatePlates(Weight.build(215, "lb"), settings, exerciseType).plates;
       expect(result).to.eql([
-        { weight: Weight.build(45, "lb"), num: 2 },
-        { weight: Weight.build(5, "lb"), num: 4 },
-        { weight: Weight.build(2.5, "lb"), num: 4 },
+        { weight: Weight.build(45, "lb"), num: 4 },
       ]);
     });
   });


### PR DESCRIPTION
As discussed on Discord:

Currently weight and plate calculation searches for a set of plates that doesn't exceed the target weight. Effectively a 'floor' of the target weight to the smallest plate weight.

It is  better however to get 'as close as possible' to the target weight using the available plates. (Equivalent to 'rounding'.)

The floor vs rounding issue is most prominent when using percentage based workouts or warmup. 

e.g. say your workout weight is  52.5kg, and you want to warmup at 90% (10% difference).  Further say our smallest plate is 1.25kg, resulting in steps of 2.5kg. As currently implemented the resulting warmup will be at 45kg, effectively a 14,3% delta; with the proposed change the warmup will be at 47.5kg, effectively 9,5%.

