### PR TITLE
Improve calorie estimate for Apple and Google Health

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -500,6 +500,7 @@ export function AppView(props: IProps): JSX.Element | null {
       <ScreenFinishDay
         navCommon={navCommon}
         settings={state.storage.settings}
+        stats={state.storage.stats}
         dispatch={dispatch}
         history={state.storage.history}
         userId={state.user?.id}

--- a/src/components/screenFinishDay.tsx
+++ b/src/components/screenFinishDay.tsx
@@ -8,7 +8,7 @@ import { Weight } from "../models/weight";
 import { Exercise } from "../models/exercise";
 import { useState } from "preact/hooks";
 import { Confetti } from "./confetti";
-import { IHistoryRecord, IScreenMuscle, ISet, ISettings } from "../types";
+import { IHistoryRecord, IScreenMuscle, ISet, ISettings, IStats, IWeight } from "../types";
 import { NavbarView } from "./navbar";
 import { Surface } from "./surface";
 import { INavCommon } from "../models/state";
@@ -34,10 +34,12 @@ import { ClipboardUtils } from "../utils/clipboard";
 import { InternalLink } from "../internalLink";
 import { LinkButton } from "./linkButton";
 import { IconTiktok } from "./icons/iconTiktok";
+import { Stats } from "../models/stats";
 
 interface IProps {
   history: IHistoryRecord[];
   settings: ISettings;
+  stats: IStats;
   userId?: string;
   dispatch: IDispatch;
   navCommon: INavCommon;
@@ -45,6 +47,8 @@ interface IProps {
 
 export function ScreenFinishDay(props: IProps): JSX.Element {
   const record = props.history[0];
+
+  const currentBodyweight: IWeight | undefined = Stats.getCurrentBodyweight(props.stats);
 
   const allPrs = History.getPersonalRecords(props.history);
   const recordPrs = allPrs[record.id] || {};
@@ -190,7 +194,7 @@ export function ScreenFinishDay(props: IProps): JSX.Element {
                     (HealthSync.eligibleForGoogleHealth() && syncToGoogleHealth)
                       ? "true"
                       : "false",
-                  calories: `${History.calories(record)}`,
+                  calories: `${History.calories(record, currentBodyweight)}`,
                   intervals: JSON.stringify(record.intervals),
                 });
                 ScreenActions.setScreen(props.dispatch, "main");

--- a/src/models/history.ts
+++ b/src/models/history.ts
@@ -520,10 +520,21 @@ export namespace History {
     return undefined;
   }
 
-  export function calories(historyRecord: IHistoryRecord): number {
+  export function calories(historyRecord: IHistoryRecord, currentWeight?: IWeight): number {
     const timeMs = workoutTime(historyRecord);
     const minutes = Math.floor(timeMs / 60000);
-    return minutes * 6;
+
+    // Metabolic Equivalent of Task (MET) value of moderate weight training is 5
+    // https://www.healthline.com/health/what-are-mets#calorie-connection
+    const MET = 5;
+    const weightKg = currentWeight ? Weight.convertTo(currentWeight, "kg").value : undefined;
+
+    // Formula for calculating calories burned from MET
+    // https://blog.nasm.org/metabolic-equivalents-for-weight-loss#:~:text=How%20To%20Calculate%20METS
+    const estimatedCaloriesFromMET = weightKg ? minutes * ((MET * 3.5 * weightKg) / 200) : undefined;
+
+    // If we don't have the user's weight, we'll just use a default multiplier
+    return estimatedCaloriesFromMET ? Math.floor(estimatedCaloriesFromMET) : minutes * 6;
   }
 
   export function getHistoricalAmrapSets(


### PR DESCRIPTION
If we have the user's weight, let's use that to get a better estimate for how many calories the user burned. This is better than just multiplying by 6 for all users and should be decently accurate until full apple watch and google watch apps