### PR TITLE
Fix crash when setting nativeNotificationScheduled on empty progress

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -240,14 +240,7 @@ export function AppView(props: IProps): JSX.Element | null {
           );
         }
       } else if (event.data?.type === "timerScheduled") {
-        if (Progress.getProgress(stateRef.current)?.ui) {
-          SendMessage.print(`Main app: Marking native notification as scheduled`);
-          updateState(
-            dispatch,
-            [Progress.lbProgress().pi("ui").p("nativeNotificationScheduled").record(true)],
-            "Set native notification scheduled"
-          );
-        }
+        dispatch(Thunk.markNativeNotificationScheduled());
       } else if (event.data?.type === "watchStorageMerge") {
         const storageJson = event.data.storage as string;
         const deviceId = event.data.deviceId as string;

--- a/src/ducks/thunks.ts
+++ b/src/ducks/thunks.ts
@@ -527,6 +527,21 @@ export namespace Thunk {
     };
   }
 
+  export function markNativeNotificationScheduled(): IThunk {
+    return async (dispatch, getState) => {
+      const state = getState();
+      const progress = Progress.getProgress(state);
+      if (progress?.ui) {
+        SendMessage.print(`Main app: Marking native notification as scheduled`);
+        updateState(
+          dispatch,
+          [Progress.lbProgress().pi("ui").p("nativeNotificationScheduled").record(true)],
+          "Set native notification scheduled"
+        );
+      }
+    };
+  }
+
   export function handleWatchStorageMerge(storageJson: string, watchDeviceId: string): IThunk {
     return async (dispatch, getState) => {
       try {


### PR DESCRIPTION
## Summary
- Fixed a crash that occurred when the `timerScheduled` event fired after a workout had finished
- The issue was a race condition where `stateRef.current` was checked for progress existence, but by the time the action reached the reducer, progress had been cleared
- Moved the logic into a thunk (`markNativeNotificationScheduled`) that reads current state before dispatching

## Root Cause
When a timer notification was scheduled by the native app and the workout ended before the notification fired, the `timerScheduled` message handler tried to set `storage.progress[0].ui.nativeNotificationScheduled = true` on an empty `progress` array.

The guard `Progress.getProgress(stateRef.current)?.ui` used a React ref which could be stale - the state might have changed between the check and when the reducer processed the action.

## Test plan
- [ ] Start a workout with timer notifications enabled
- [ ] Complete a set to start the rest timer
- [ ] Quickly finish the workout before the timer ends
- [ ] Verify no crash occurs when the native notification would have fired

**Rollbar occurrence:** https://rollbar.com/liftosaur/Liftosaur/items/.../occurrences/453425925501/

🤖 Generated with [Claude Code](https://claude.ai/code)