### PR TITLE
Fix: Handle undefined in PlannerEvaluator.evaluate memoization (Rollbar #453486005273)

### DIFF
--- a/src/pages/planner/plannerEvaluator.ts
+++ b/src/pages/planner/plannerEvaluator.ts
@@ -789,6 +789,9 @@ export class PlannerEvaluator {
   public static evaluate = memoize(this.forceEvaluate, {
     maxSize: 10,
     isEqual: (a: IPlannerProgram | ISettings, b: IPlannerProgram | ISettings) => {
+      if (a == null || b == null) {
+        return a === b;
+      }
       if ("weeks" in a && "weeks" in b) {
         const aText = PlannerProgram.generateFullText(a.weeks);
         const bText = PlannerProgram.generateFullText(b.weeks);


### PR DESCRIPTION
## Summary
- Add null/undefined check to `isEqual` function in `PlannerEvaluator.evaluate` memoization config
- Prevents `TypeError: Cannot use 'in' operator to search for 'weeks' in undefined`

## Decision
This is a valid bug in our code that should be fixed. The error occurs during server-side rendering when:
1. `PlannerContent` renders and `state.current.program.planner` is `undefined`
2. It's passed to `PlannerProgram.isValid()` which calls memoized `PlannerEvaluator.evaluate()`
3. The micro-memoize `isEqual` callback tries to use `in` operator on `undefined`

## Root Cause
The `isEqual` function for the memoized `evaluate` function didn't handle `undefined` arguments. When `planner` was `undefined` (which can happen if `program.planner` is null), the comparison `"weeks" in a` would throw.

## Test plan
- [x] Build succeeds
- [x] All 247 unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)