### PR TITLE
fix-rollbar (1523833717/454168013129): Ignore SSLHandshakeException connection closed

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -35,6 +35,7 @@ export const exceptionIgnores = [
   "Invalid position",
   "outdated_client_storage",
   '{"isTrusted":true}',
+  "connection closed",
 ];
 
 export namespace RollbarUtils {


### PR DESCRIPTION
## Summary
- Added "connection closed" to the `exceptionIgnores` list in `src/utils/rollbar.ts`

## Decision
This error should be **ignored** — it is a transient Android-native SSL handshake failure (`javax.net.ssl.SSLHandshakeException: connection closed`) that occurs in the system network layer (`com.android.okhttp`, `com.android.org.conscrypt`) during `shouldInterceptRequest` in the Android WebView. No JavaScript/TypeScript code is involved, and the error is not actionable.

The device is a moto g22 on Android 12 with likely poor network connectivity.

## Root Cause
The Android WebView's `shouldInterceptRequest` opens an HTTP connection to cache resources. When the SSL/TLS handshake fails due to the remote server or network dropping the connection (`java.io.EOFException: connection closed`), the exception is caught and reported to Rollbar. This is a transient network condition outside our control.

**Note:** The `exceptionIgnores` list in the JS Rollbar config may not catch this specific error since it originates from the Android Rollbar SDK (native Java). A follow-up change in the Android project (`LiftosaurAndroid`) to catch `SSLHandshakeException` separately in `shouldInterceptRequest` (without reporting to Rollbar) would fully suppress these.

## Test plan
- [ ] Verify build succeeds
- [ ] Verify unit tests pass
- [ ] Confirm "connection closed" string added to ignore list

🤖 Generated with [Claude Code](https://claude.ai/code)