### PR TITLE
fix-rollbar (1721341259/454164699764): fix crash when SSR planner page with legacy program

### DIFF
--- a/src/pages/planner/models/plannerProgram.ts
+++ b/src/pages/planner/models/plannerProgram.ts
@@ -47,7 +47,10 @@ export class PlannerDayDataError extends Error {
 export type IDereuseDecision = "all" | "weight" | "rpe" | "timer";
 
 export class PlannerProgram {
-  public static isValid(program: IPlannerProgram, settings: ISettings): boolean {
+  public static isValid(program: IPlannerProgram | undefined, settings: ISettings): boolean {
+    if (!program) {
+      return false;
+    }
     const { evaluatedWeeks } = PlannerProgram.evaluate(program, settings);
     return evaluatedWeeks.every((week) => week.every((day) => day.success));
   }

--- a/src/pages/planner/plannerContent.tsx
+++ b/src/pages/planner/plannerContent.tsx
@@ -133,10 +133,9 @@ export function PlannerContent(props: IPlannerContentProps): JSX.Element {
     weeks: [initialWeek],
   };
 
-  const initialProgram = props.initialProgram?.program || {
-    ...Program.create("My Program"),
-    planner: initialPlanner,
-  };
+  const initialProgram = props.initialProgram?.program
+    ? { ...props.initialProgram.program, planner: props.initialProgram.program.planner || initialPlanner }
+    : { ...Program.create("My Program"), planner: initialPlanner };
 
   const initialSettings: ISettings = Settings.build();
   initialSettings.exercises = {


### PR DESCRIPTION
## Summary
- Fix `TypeError: Cannot read properties of undefined (reading 'weeks')` in `PlannerEvaluator.getPerDayEvaluatedWeeks`
- Ensure `initialPlanner` fallback is applied when legacy programs lack a `planner` property
- Add defensive null check in `PlannerProgram.isValid`

## Decision
Fixed - this error affects server-side rendering of the planner page when a Prerender bot requests `/planner/<encoded-data>` with a legacy (non-planner) exported program.

## Root Cause
When `props.initialProgram.program` exists but has no `planner` property (legacy programs), the `||` fallback on line 136 of `plannerContent.tsx` short-circuits because the program object is truthy. The `initialPlanner` fallback computed on line 130 was never applied, leaving `state.current.program.planner` as `undefined`. This flows through `PlannerProgram.isValid` → `PlannerProgram.evaluate` → `PlannerEvaluator.getPerDayEvaluatedWeeks` which crashes on `plannerProgram.weeks.map(...)`.

## Test plan
- [ ] Verify build succeeds
- [ ] Verify all unit tests pass (247 passing)
- [ ] Server-side render `/planner` with no data parameter
- [ ] Server-side render `/planner/<encoded-legacy-program>` with a legacy program without planner

🤖 Generated with [Claude Code](https://claude.ai/code)