### PR TITLE
fix-rollbar (1718168039/454217098130): guard against null event.data in message handlers

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -204,7 +204,7 @@ export function AppView(props: IProps): JSX.Element | null {
         const restTimer = event.data.restTimer as number;
         const restTimerSince = event.data.restTimerSince as number;
         dispatch(Thunk.completeSetExternal(entryIndex, setIndex, restTimer, restTimerSince));
-      } else if (event.data.type === "adjustRestTimer") {
+      } else if (event.data?.type === "adjustRestTimer") {
         const action = event.data.action as "increase" | "decrease";
         const incomingRestTimer = event.data.restTimer as number;
         const incomingRestTimerSince = event.data.restTimerSince as number;

--- a/src/utils/nativeStorage.ts
+++ b/src/utils/nativeStorage.ts
@@ -55,7 +55,9 @@ export class NativeStorage {
   constructor() {
     this.pendingRequests = new Map();
     window.addEventListener("message", (event) => {
-      this.handleResponse(event.data);
+      if (event.data != null) {
+        this.handleResponse(event.data);
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- Add optional chaining (`?.`) for `event.data.type` check in `adjustRestTimer` branch in `app.tsx` — all other branches already had it
- Add null guard before calling `handleResponse(event.data)` in `nativeStorage.ts`

## Decision
Fixed because this is a real null-safety bug affecting normal user flows on Android WebView. The `message` event can deliver `null` as `event.data` (e.g. from WebView bridge or third-party scripts), and missing null guards caused a TypeError crash.

## Root Cause
In the `window.addEventListener("message", ...)` handler in `app.tsx`, all `event.data?.type` checks used optional chaining except the `adjustRestTimer` branch (line 207), which used `event.data.type` directly. When `event.data` was `null`, this crashed with `TypeError: Cannot read properties of null (reading 'type')`.

Similarly, `NativeStorage` passed `event.data` directly to `handleResponse()` without null-checking, causing the related `Cannot read properties of null (reading 'requestId')` error.

## Test plan
- [x] Build succeeds
- [x] All 247 unit tests pass
- [ ] Verify on Android WebView that workout tracking works without errors

🤖 Generated with [Claude Code](https://claude.ai/code)