### PR TITLE
fix-rollbar (1691098453/454217098592): guard against null event.data in NativeStorage

### DIFF
--- a/src/utils/nativeStorage.ts
+++ b/src/utils/nativeStorage.ts
@@ -144,7 +144,7 @@ export class NativeStorage {
   }
 
   private handleResponse(data: IStorageResponse): void {
-    if (!data.requestId) {
+    if (data == null || typeof data !== "object" || !data.requestId) {
       return;
     }
 


### PR DESCRIPTION
## Summary
- Add null/type guard in `NativeStorage.handleResponse` before accessing `data.requestId`
- `event.data` from `window.postMessage` can be `null` or non-object (e.g. from other scripts or browser internals), causing `TypeError: Cannot read properties of null (reading 'requestId')`

## Decision
Fixed — this is a real bug in our code affecting Android WebView users. The `window` `message` event listener receives all `postMessage` events, not just our storage responses, and `event.data` can be any type including `null`.

## Root Cause
`NativeStorage` constructor registers a `window` `message` event listener that passes `event.data` directly to `handleResponse`. The method assumed `data` is always an object, but `event.data` can be `null` when other scripts or the browser post messages with null data. The fix adds `data == null || typeof data !== "object"` checks before accessing `.requestId`.

## Test plan
- [x] Build succeeds
- [x] All 247 unit tests pass
- [ ] Verify on Android WebView that native storage operations still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)