### PR TITLE
fix-rollbar (5666/454248267431): guard against null progress in card action reducer

### DIFF
--- a/src/ducks/reducer.ts
+++ b/src/ducks/reducer.ts
@@ -643,32 +643,18 @@ function pushScreen<T extends IScreen>(
 }
 
 export const reducer: Reducer<IState, IAction> = (state, action): IState => {
-  if (action.type === "CompleteSetAction") {
+  if (action.type === "CompleteSetAction" || action.type === "ChangeAMRAPAction" || action.type === "UpdateProgress") {
+    const progress = Progress.getProgress(state);
+    if (progress == null) {
+      return state;
+    }
     return Progress.setProgress(
       state,
       buildCardsReducer(
         state.storage.settings,
         state.storage.stats,
         state.storage.subscription
-      )(Progress.getProgress(state)!, action)
-    );
-  } else if (action.type === "ChangeAMRAPAction") {
-    return Progress.setProgress(
-      state,
-      buildCardsReducer(
-        state.storage.settings,
-        state.storage.stats,
-        state.storage.subscription
-      )(Progress.getProgress(state)!, action)
-    );
-  } else if (action.type === "UpdateProgress") {
-    return Progress.setProgress(
-      state,
-      buildCardsReducer(
-        state.storage.settings,
-        state.storage.stats,
-        state.storage.subscription
-      )(Progress.getProgress(state)!, action)
+      )(progress, action)
     );
   } else if (action.type === "StartProgramDayAction") {
     const progress = Progress.getProgress(state);


### PR DESCRIPTION
## Summary
- Guard against null/undefined progress in the reducer when handling CompleteSetAction, ChangeAMRAPAction, and UpdateProgress actions
- Consolidate three identical action cases into a single branch with a null check, returning state unchanged when no active progress exists

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/5666/occurrence/454248267431

## Decision
Fixed because this is a race condition in our code that affects normal user flows - the onScroll handler in the Workout component dispatches UpdateProgress after the workout has been finished and progress cleared.

## Root Cause
When a user finishes a workout and navigates back, the scroll event handler in the Workout component can still fire asynchronously. By the time the UpdateProgress action reaches the reducer, Progress.getProgress(state) returns undefined (progress was already cleared). The non-null assertion then causes the lens operation to fail with "undefined is not an object" when trying to set ui.currentEntryIndex.

## Test plan
- [ ] Start a workout and finish it
- [ ] After clicking Continue on the finish screen, quickly scroll and press back
- [ ] Verify no error occurs and the app navigates back to the main screen normally
- [ ] Verify normal workout flow (start, complete sets, finish) still works correctly