### PR TITLE
fix-rollbar (1696649553/454192152013): guard against undefined window.indexedDB

### DIFF
--- a/src/utils/indexeddb.ts
+++ b/src/utils/indexeddb.ts
@@ -83,6 +83,10 @@ export namespace IndexedDBUtils {
       if (nativeStorage == null && NativeStorage.isAvailable()) {
         nativeStorage = new NativeStorage();
       }
+      if (typeof window === "undefined" || !window.indexedDB) {
+        resolve();
+        return;
+      }
       const connection = window.indexedDB.open("keyval-store");
       const handler = (): void => {
         if (connection.result != null) {
@@ -108,6 +112,10 @@ export namespace IndexedDBUtils {
         nativeStorage = new NativeStorage();
       }
 
+      if (typeof window === "undefined" || !window.indexedDB) {
+        reject(new Error("IndexedDB is not available"));
+        return;
+      }
       const connection = window.indexedDB.open("keyval-store");
       connection.addEventListener("success", (event) => {
         const request = event.target as IDBOpenDBRequest;


### PR DESCRIPTION
## Summary
- Add null guards for `window.indexedDB` in `IndexedDBUtils.initialize()` and `IndexedDBUtils.initializeForSafari()` 
- When IndexedDB is unavailable, `initialize()` rejects gracefully (caught by existing error handling in `withTransaction`) and `initializeForSafari()` resolves as a no-op

## Decision
Fix — this is a real crash affecting iOS Safari users during normal app usage.

## Root Cause
On iOS Safari (especially iOS 15), `window.indexedDB` can become `undefined` after extended runtime (~70+ minutes) due to storage pressure or WebView state changes. The code was calling `window.indexedDB.open()` without checking if `window.indexedDB` exists, causing a `TypeError: undefined is not an object (evaluating 'window.indexedDB.open')`.

## Test plan
- [x] Unit tests pass (247 passing)
- [x] Build succeeds
- [ ] Verify on iOS simulator that app works normally with IndexedDB available
- [ ] Verify graceful degradation when IndexedDB is unavailable

🤖 Generated with [Claude Code](https://claude.ai/code)