### PR TITLE
fix-rollbar (4990/454291448003): guard against stale blur dispatches after edit set modal save

### DIFF
--- a/src/components/bottomSheetEditTarget.tsx
+++ b/src/components/bottomSheetEditTarget.tsx
@@ -5,7 +5,7 @@ import { MenuItemWrapper } from "./menuItem";
 import { InputNumber2 } from "./inputNumber2";
 import { IDispatch } from "../ducks/types";
 import { InputWeight2 } from "./inputWeight2";
-import { useState } from "preact/hooks";
+import { useRef, useState } from "preact/hooks";
 import { MenuItemEditable } from "./menuItemEditable";
 import { IconTrash } from "./icons/iconTrash";
 import { lb } from "lens-shmens";
@@ -32,6 +32,7 @@ function BottomSheetEditTargetContent(props: IBottomSheetEditTargetContentProps)
   const [enableRpe, setEnableRpe] = useState(set.rpe != null);
   const [enableTimer, setEnableTimer] = useState(set.timer != null);
   const lbSet = lb<IHistoryRecord>().pi("ui").pi("editSetModal").pi("set");
+  const savedRef = useRef(false);
 
   return (
     <div className="px-4 pb-4">
@@ -45,10 +46,12 @@ function BottomSheetEditTargetContent(props: IBottomSheetEditTargetContentProps)
               <InputNumber2
                 width={2.5}
                 name="target-minreps"
-                onBlur={(value) =>
-                  updateProgress(props.dispatch, [lbSet.p("minReps").record(value)], "target-blur-minreps")
-                }
+                onBlur={(value) => {
+                  if (savedRef.current) return;
+                  updateProgress(props.dispatch, [lbSet.p("minReps").record(value)], "target-blur-minreps");
+                }}
                 onInput={(value) => {
+                  if (savedRef.current) return;
                   if (value != null && !isNaN(value) && value >= 0) {
                     updateProgress(props.dispatch, [lbSet.p("minReps").record(value)], "target-input-minreps");
                   }
@@ -64,10 +67,12 @@ function BottomSheetEditTargetContent(props: IBottomSheetEditTargetContentProps)
               <InputNumber2
                 width={2.5}
                 name="target-maxreps"
-                onBlur={(value) =>
-                  updateProgress(props.dispatch, [lbSet.p("reps").record(value)], "target-blur-maxreps")
-                }
+                onBlur={(value) => {
+                  if (savedRef.current) return;
+                  updateProgress(props.dispatch, [lbSet.p("reps").record(value)], "target-blur-maxreps");
+                }}
                 onInput={(value) => {
+                  if (savedRef.current) return;
                   if (value == null || (!isNaN(value) && value >= 0)) {
                     updateProgress(props.dispatch, [lbSet.p("reps").record(value)], "target-input-maxreps");
                   }
@@ -105,6 +110,7 @@ function BottomSheetEditTargetContent(props: IBottomSheetEditTargetContentProps)
                 subscription={props.subscription}
                 exerciseType={props.editSetModal.exerciseType}
                 onBlur={(value) => {
+                  if (savedRef.current) return;
                   updateProgress(
                     props.dispatch,
                     [lbSet.p("originalWeight").record(value ?? Weight.build(0, "lb"))],
@@ -112,6 +118,7 @@ function BottomSheetEditTargetContent(props: IBottomSheetEditTargetContentProps)
                   );
                 }}
                 onInput={(value) => {
+                  if (savedRef.current) return;
                   if (value != null) {
                     updateProgress(
                       props.dispatch,
@@ -172,8 +179,12 @@ function BottomSheetEditTargetContent(props: IBottomSheetEditTargetContentProps)
                   allowDot={true}
                   width={2.5}
                   name="target-rpe"
-                  onBlur={(value) => updateProgress(props.dispatch, [lbSet.p("rpe").record(value)], "target-blur-rpe")}
+                  onBlur={(value) => {
+                    if (savedRef.current) return;
+                    updateProgress(props.dispatch, [lbSet.p("rpe").record(value)], "target-blur-rpe");
+                  }}
                   onInput={(value) => {
+                    if (savedRef.current) return;
                     if (value != null && !isNaN(value) && value >= 0) {
                       updateProgress(props.dispatch, [lbSet.p("rpe").record(value)], "target-input-rpe");
                     }
@@ -238,10 +249,12 @@ function BottomSheetEditTargetContent(props: IBottomSheetEditTargetContentProps)
                 <InputNumber2
                   width={2.5}
                   name="target-timer"
-                  onBlur={(value) =>
-                    updateProgress(props.dispatch, [lbSet.p("timer").record(value)], "target-blur-timer")
-                  }
+                  onBlur={(value) => {
+                    if (savedRef.current) return;
+                    updateProgress(props.dispatch, [lbSet.p("timer").record(value)], "target-blur-timer");
+                  }}
                   onInput={(value) => {
+                    if (savedRef.current) return;
                     if (value != null && !isNaN(value) && value >= 0) {
                       updateProgress(props.dispatch, [lbSet.p("timer").record(value)], "target-input-timer");
                     }
@@ -276,6 +289,7 @@ function BottomSheetEditTargetContent(props: IBottomSheetEditTargetContentProps)
           data-cy="edit-set-target-save"
           className="w-full"
           onClick={() => {
+            savedRef.current = true;
             const evaluatedWeight = set.originalWeight
               ? Weight.evaluateWeight(
                   set.originalWeight,


### PR DESCRIPTION
## Summary
- Add `savedRef` guard in `BottomSheetEditTargetContent` to prevent `onBlur`/`onInput` callbacks from dispatching state updates after the Save button has been clicked
- When Save is clicked, `editSetModal` is set to `undefined` in state, but async blur events (10ms `setTimeout` in `InputNumber2`) can still fire and try to update through the now-undefined lens path

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/4990/occurrence/454291448003

## Decision
Fixed because this is a real error affecting normal user flows — editing set targets and clicking Save triggers a LensError when the blur fires after the modal state is cleared.

## Root Cause
When a user clicks the Save button in the Edit Set Target modal, two things happen in sequence:
1. The save handler sets `editSetModal` to `undefined` in the progress state
2. The input blur event fires asynchronously (via `setTimeout` with 10ms delay in `InputNumber2`) and tries to dispatch an `UpdateProgress` action through `lbSet.p("originalWeight")`, where `lbSet` includes the path `ui.editSetModal.set` — but `editSetModal` is already `undefined`, causing the lens to throw

The telemetry shows the user clicked the Save button (the purple card button) rapidly, which triggered the blur on the weight input after the modal was already dismissed.

## Test plan
- [ ] Start a workout, complete a set, click edit on a set
- [ ] Edit the weight value, then click Save — verify it saves correctly
- [ ] Rapidly double-click Save while weight input is focused — verify no error
- [ ] Unit tests pass (247/247)
- [ ] Playwright E2E tests pass (32/33, only known flaky `subscriptions.spec.ts` fails)