### PR TITLE
fix-rollbar (3743/454289675972): guard against undefined progress on progress screen

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -408,7 +408,10 @@ export function AppView(props: IProps): JSX.Element | null {
       throw new Error("Program is not selected on the 'main' screen");
     }
   } else if (Screen.currentName(state.screenStack) === "progress") {
-    const progress = Progress.getProgress(state)!;
+    const progress = Progress.getProgress(state);
+    if (progress == null) {
+      return null;
+    }
     const program = Progress.isCurrent(progress)
       ? Program.getFullProgram(state, progress.programId) ||
         (currentProgram ? Program.fullProgram(currentProgram, state.storage.settings) : undefined)


### PR DESCRIPTION
## Summary
- Guard against `Progress.getProgress(state)` returning `undefined` when the screen is "progress"
- Removed unsafe non-null assertion (`!`) and added an early return of `null` when progress data is missing
- Prevents TypeError crash: `undefined is not an object (evaluating 'e.id')`

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/3743/occurrence/454289675972

## Decision
Fixed because this is a crash in core workout functionality that occurs when a user starts a workout but the progress state is missing (likely due to a race condition during sync or state clearing).

## Root Cause
`Progress.getProgress(state)` can return `undefined` when `state.storage.progress` is empty (e.g., after a sync clears the progress data while the screen stack still shows "progress"). The code used a non-null assertion (`!`) which bypassed TypeScript's null check, causing `Progress.isCurrent(progress)` to crash when accessing `progress.id` on `undefined`.

## Test plan
- [ ] Unit tests pass (247 passing)
- [ ] Playwright E2E tests pass (32/33 - only known flaky subscription test fails)
- [ ] Start a workout, verify it works normally
- [ ] Verify that if progress state becomes undefined while on progress screen, app doesn't crash