### PR TITLE
fix-rollbar (3743/454306659155): guard against null progress in AppView progress screen

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -408,27 +408,34 @@ export function AppView(props: IProps): JSX.Element | null {
       throw new Error("Program is not selected on the 'main' screen");
     }
   } else if (Screen.currentName(state.screenStack) === "progress") {
-    const progress = Progress.getProgress(state)!;
-    const program = Progress.isCurrent(progress)
-      ? Program.getFullProgram(state, progress.programId) ||
-        (currentProgram ? Program.fullProgram(currentProgram, state.storage.settings) : undefined)
-      : undefined;
-    content = (
-      <ScreenWorkout
-        navCommon={navCommon}
-        stats={state.storage.stats}
-        helps={state.storage.helps}
-        history={state.storage.history}
-        subscription={state.storage.subscription}
-        userId={state.user?.id}
-        progress={progress}
-        allPrograms={state.storage.programs}
-        program={program}
-        currentProgram={currentProgram}
-        dispatch={dispatch}
-        settings={state.storage.settings}
-      />
-    );
+    const progress = Progress.getProgress(state);
+    if (progress == null) {
+      setTimeout(() => {
+        dispatch(Thunk.pullScreen());
+      }, 0);
+      content = <></>;
+    } else {
+      const program = Progress.isCurrent(progress)
+        ? Program.getFullProgram(state, progress.programId) ||
+          (currentProgram ? Program.fullProgram(currentProgram, state.storage.settings) : undefined)
+        : undefined;
+      content = (
+        <ScreenWorkout
+          navCommon={navCommon}
+          stats={state.storage.stats}
+          helps={state.storage.helps}
+          history={state.storage.history}
+          subscription={state.storage.subscription}
+          userId={state.user?.id}
+          progress={progress}
+          allPrograms={state.storage.programs}
+          program={program}
+          currentProgram={currentProgram}
+          dispatch={dispatch}
+          settings={state.storage.settings}
+        />
+      );
+    }
   } else if (Screen.currentName(state.screenStack) === "settings") {
     content = (
       <ScreenSettings


### PR DESCRIPTION
## Summary
- Guard against `progress` being `undefined` when rendering the progress screen in `AppView`
- When progress is null, dispatch `pullScreen()` to navigate back instead of crashing

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/3743/occurrence/454306659155

## Decision
Fixed because the error crashes the app for users who navigate to a progress screen right after stopping a workout (race condition where progress is cleared but screen is pushed).

## Root Cause
When a user stops a workout, `storage.progress` is cleared and the screen is pulled back. However, a subsequent `PushScreen` to the progress screen (with a historical workout ID) can happen in the same dispatch cycle. At that point, `state.progress[id]` is `undefined` because the historical progress entry was never loaded. The `!` non-null assertion on `Progress.getProgress(state)!` then passes `undefined` to `Progress.isCurrent()`, which crashes on `progress.id`.

## Test plan
- [x] TypeScript type check passes
- [x] Lint passes
- [x] Unit tests pass (247 passing)
- [x] Playwright E2E tests pass (31 passed, 2 known flaky)