### PR TITLE
fix-rollbar (5858/454303293591): add vtypes migration for progress records

### DIFF
--- a/src/migrations/migrations.ts
+++ b/src/migrations/migrations.ts
@@ -364,4 +364,33 @@ export const migrations = {
     }
     return storage;
   },
+  "20260211120000_add_vtypes_to_progress": (aStorage: IStorage): IStorage => {
+    const storage: IStorage = JSON.parse(JSON.stringify(aStorage));
+    for (const record of storage.progress || []) {
+      record.vtype = record.vtype || "progress";
+      const progressUi = record.ui;
+      if (progressUi) {
+        progressUi.vtype = progressUi.vtype || "progress_ui";
+        if (!progressUi.id) {
+          progressUi.id = UidFactory.generateUid(8);
+        }
+      }
+      for (let entryIndex = 0; entryIndex < record.entries.length; entryIndex++) {
+        const entry = record.entries[entryIndex];
+        entry.vtype = entry.vtype || "history_entry";
+        entry.index = entry.index ?? entryIndex;
+        for (let setIndex = 0; setIndex < entry.sets.length; setIndex++) {
+          const set = entry.sets[setIndex];
+          set.vtype = set.vtype || "set";
+          set.index = set.index ?? setIndex;
+        }
+        for (let setIndex = 0; setIndex < entry.warmupSets.length; setIndex++) {
+          const set = entry.warmupSets[setIndex];
+          set.vtype = set.vtype || "set";
+          set.index = set.index ?? setIndex;
+        }
+      }
+    }
+    return storage;
+  },
 };


### PR DESCRIPTION
## Summary
- Added migration `20260211120000_add_vtypes_to_progress` to populate missing `vtype`, `index`, and `id` fields on `storage.progress` records
- The existing migration `20251231182918_add_vtypes_and_indexes_to_entries_and_sets` only processed `storage.history` but not `storage.progress`, leaving progress records without required discriminator fields

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/5858/occurrence/454303293591

## Decision
Fixed because this affects users who had an in-progress workout saved before vtypes were introduced. When the app validates storage on state changes, the progress record fails THistoryRecord io-ts validation due to missing `vtype` fields on the record, entries, and sets.

## Root Cause
Migration `20251231182918` added vtypes to `storage.history` records but did not process `storage.progress` records. Users with old progress records (created before vtypes existed) hit validation errors on every state change because the progress record lacks required `vtype` discriminator fields.

## Test plan
- [x] TypeScript compilation passes
- [x] ESLint passes
- [x] All 247 unit tests pass
- [x] All 32 Playwright E2E tests pass (1 flaky subscription test, unrelated)