### PR TITLE
fix-rollbar (4997/454338759616): prevent crash when warmup sets deleted while input focused

### DIFF
--- a/src/components/editProgramExercise/editProgramExerciseWarmups.tsx
+++ b/src/components/editProgramExercise/editProgramExerciseWarmups.tsx
@@ -33,12 +33,14 @@ function changeWeight(
 ): IPlannerProgram {
   return EditProgramUiHelpers.changeFirstInstance(planner, plannerExercise, settings, true, (e) => {
     e.warmupSets = PlannerProgramExercise.degroupWarmupSets(e.warmupSets || []);
-    if (value.unit === "%") {
-      e.warmupSets[setIndex].percentage = value.value;
-      e.warmupSets[setIndex].weight = undefined;
-    } else {
-      e.warmupSets[setIndex].weight = value;
-      e.warmupSets[setIndex].percentage = undefined;
+    if (e.warmupSets[setIndex] != null) {
+      if (value.unit === "%") {
+        e.warmupSets[setIndex].percentage = value.value;
+        e.warmupSets[setIndex].weight = undefined;
+      } else {
+        e.warmupSets[setIndex].weight = value;
+        e.warmupSets[setIndex].percentage = undefined;
+      }
     }
   });
 }
@@ -52,7 +54,9 @@ function changeReps(
 ): IPlannerProgram {
   return EditProgramUiHelpers.changeFirstInstance(planner, plannerExercise, settings, true, (e) => {
     e.warmupSets = PlannerProgramExercise.degroupWarmupSets(e.warmupSets || []);
-    e.warmupSets[setIndex].reps = value;
+    if (e.warmupSets[setIndex] != null) {
+      e.warmupSets[setIndex].reps = value;
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- Added null check in `changeWeight()` before modifying `warmupSets[setIndex]`
- Added null check in `changeReps()` before modifying `warmupSets[setIndex]`

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/4997/occurrence/454338759616

## Decision
This was fixed because it's a legitimate crash affecting normal user flows when editing warmup sets.

## Root Cause
Race condition between input blur handlers and the "customize warmups" toggle button. The sequence:

1. User has warmup sets displayed with input fields for reps/weight
2. User focuses on an input field (but doesn't blur it yet)
3. User clicks "customize warmups" button, which deletes all warmup sets
4. The focused input field triggers its `onBlur` handler
5. The `onBlur` calls `changeWeight()` or `changeReps()` with the old `setIndex`
6. Code tries to access `warmupSets[setIndex]` but it's undefined after deletion
7. TypeError: `undefined is not an object (evaluating 'e.warmupSets[r].percentage=n.value')`

## Test plan
- [x] TypeScript compilation passes
- [x] Unit tests pass (247 passing)
- [ ] Playwright tests will run in CI (browsers not installed in worktree environment)