### PR TITLE
fix-rollbar (2801/454347745318): Fix Apple Sign In SDK race condition

### DIFF
--- a/src/components/account.tsx
+++ b/src/components/account.tsx
@@ -115,12 +115,14 @@ function AccountLoggedOutView(props: IAccountLoggedOutViewProps): JSX.Element {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    window.AppleID.auth.init({
-      clientId: "com.liftosaur.www.signinapple", // This is the service ID we created.
-      scope: "email", // To tell apple we want the user name and emails fields in the response it sends us.
-      redirectURI: `${__HOST__}/appleauthcallback.html`, // As registered along with our service ID
-      usePopup: true, // Important if we want to capture the data apple sends on the client side.
-    });
+    if (window.AppleID?.auth) {
+      window.AppleID.auth.init({
+        clientId: "com.liftosaur.www.signinapple", // This is the service ID we created.
+        scope: "email", // To tell apple we want the user name and emails fields in the response it sends us.
+        redirectURI: `${__HOST__}/appleauthcallback.html`, // As registered along with our service ID
+        usePopup: true, // Important if we want to capture the data apple sends on the client side.
+      });
+    }
   }, []);
 
   return (
@@ -175,6 +177,11 @@ function AccountLoggedOutView(props: IAccountLoggedOutViewProps): JSX.Element {
                 setIsLoading(true);
                 if (props.dispatch) {
                   props.dispatch(Thunk.appleSignIn(() => setIsLoading(false)));
+                  return;
+                }
+                if (!window.AppleID?.auth) {
+                  setIsLoading(false);
+                  alert("Apple Sign In is not available");
                   return;
                 }
                 const response = await window.AppleID.auth.signIn();

--- a/src/components/screenAccount.tsx
+++ b/src/components/screenAccount.tsx
@@ -42,12 +42,14 @@ export function ScreenAccount(props: IProps): JSX.Element {
 
   useEffect(() => {
     refetchAccounts();
-    window.AppleID.auth.init({
-      clientId: "com.liftosaur.www.signinapple", // This is the service ID we created.
-      scope: "email", // To tell apple we want the user name and emails fields in the response it sends us.
-      redirectURI: `${__HOST__}/appleauthcallback.html`, // As registered along with our service ID
-      usePopup: true, // Important if we want to capture the data apple sends on the client side.
-    });
+    if (window.AppleID?.auth) {
+      window.AppleID.auth.init({
+        clientId: "com.liftosaur.www.signinapple", // This is the service ID we created.
+        scope: "email", // To tell apple we want the user name and emails fields in the response it sends us.
+        redirectURI: `${__HOST__}/appleauthcallback.html`, // As registered along with our service ID
+        usePopup: true, // Important if we want to capture the data apple sends on the client side.
+      });
+    }
   }, []);
 
   return (

--- a/src/ducks/thunks.ts
+++ b/src/ducks/thunks.ts
@@ -106,6 +106,13 @@ export namespace Thunk {
           ({ id_token, code } = result);
         }
       } else {
+        if (!window.AppleID?.auth) {
+          alert("Apple Sign In is not available");
+          if (cb) {
+            cb();
+          }
+          return;
+        }
         const response = await window.AppleID.auth.signIn();
         ({ id_token, code } = response.authorization);
       }


### PR DESCRIPTION
## Summary
- Add null checks for `window.AppleID?.auth` before calling `init()` and `signIn()`
- Add user-friendly error message when Apple Sign In SDK is not available
- Fix race condition in 3 locations: `account.tsx`, `screenAccount.tsx`, and `thunks.ts`

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/2801/occurrence/454347745318

## Decision
Fixed. This is a legitimate production error affecting users who try to sign in with Apple.

## Root Cause
The Apple Sign In SDK is loaded with an `async` script tag, creating a race condition where:
1. Component mounts and `useEffect` runs
2. `window.AppleID.auth.init()` is called
3. But the SDK script hasn't finished loading yet, so `window.AppleID` is undefined
4. TypeError: Cannot read properties of undefined (reading 'auth')

The same issue could occur when clicking "Sign in with Apple" button if the SDK hasn't loaded.

## Test plan
- [x] TypeScript compilation passes
- [x] ESLint passes
- [x] All unit tests pass (247 tests)
- [ ] E2E tests require Playwright browser installation in main repo
