### PR TITLE
fix-rollbar (3190/454353504402): Handle undefined progress in isCurrent

### DIFF
--- a/src/models/progress.ts
+++ b/src/models/progress.ts
@@ -434,8 +434,8 @@ export namespace Progress {
     return fns;
   }
 
-  export function isCurrent(progress: IHistoryRecord): boolean {
-    return progress.id === 0;
+  export function isCurrent(progress: IHistoryRecord | undefined): boolean {
+    return progress?.id === 0;
   }
 
   export function startTimer(


### PR DESCRIPTION
## Summary
- Updated Progress.isCurrent() to handle undefined progress parameter
- Changed function signature to accept IHistoryRecord | undefined
- Used optional chaining to safely access progress.id

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/3190/occurrence/454353504402

## Decision
This error was fixed because it affects normal user flows and can cause crashes when progress state is in transition.

## Root Cause
The Progress.isCurrent() function expected a non-null IHistoryRecord parameter, but Progress.getProgress() can return undefined in certain edge cases (e.g., when storage.progress is empty or during state transitions after sync). The code was using a non-null assertion operator (!) which caused the error when progress was actually undefined.

## Test plan
- [x] Built successfully (webpack)
- [x] TypeScript compilation passed
- [x] Lint passed
- [x] All unit tests passed (247 tests)
- [x] Playwright E2E tests passed (30 passed, 2 pre-existing flaky failures unrelated to this change)