### PR TITLE
fix-rollbar (3743/454356249469): Handle undefined progress on progress screen

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -354,7 +354,7 @@ export function AppView(props: IProps): JSX.Element | null {
     userId: state.user?.id,
   };
 
-  let content: JSX.Element;
+  let content: JSX.Element | undefined;
   if (Screen.currentName(state.screenStack) === "first") {
     const userId = state.user?.id;
     const userEmail = state.user?.email;
@@ -408,27 +408,29 @@ export function AppView(props: IProps): JSX.Element | null {
       throw new Error("Program is not selected on the 'main' screen");
     }
   } else if (Screen.currentName(state.screenStack) === "progress") {
-    const progress = Progress.getProgress(state)!;
-    const program = Progress.isCurrent(progress)
-      ? Program.getFullProgram(state, progress.programId) ||
-        (currentProgram ? Program.fullProgram(currentProgram, state.storage.settings) : undefined)
-      : undefined;
-    content = (
-      <ScreenWorkout
-        navCommon={navCommon}
-        stats={state.storage.stats}
-        helps={state.storage.helps}
-        history={state.storage.history}
-        subscription={state.storage.subscription}
-        userId={state.user?.id}
-        progress={progress}
-        allPrograms={state.storage.programs}
-        program={program}
-        currentProgram={currentProgram}
-        dispatch={dispatch}
-        settings={state.storage.settings}
-      />
-    );
+    const progress = Progress.getProgress(state);
+    if (progress) {
+      const program = Progress.isCurrent(progress)
+        ? Program.getFullProgram(state, progress.programId) ||
+          (currentProgram ? Program.fullProgram(currentProgram, state.storage.settings) : undefined)
+        : undefined;
+      content = (
+        <ScreenWorkout
+          navCommon={navCommon}
+          stats={state.storage.stats}
+          helps={state.storage.helps}
+          history={state.storage.history}
+          subscription={state.storage.subscription}
+          userId={state.user?.id}
+          progress={progress}
+          allPrograms={state.storage.programs}
+          program={program}
+          currentProgram={currentProgram}
+          dispatch={dispatch}
+          settings={state.storage.settings}
+        />
+      );
+    }
   } else if (Screen.currentName(state.screenStack) === "settings") {
     content = (
       <ScreenSettings


### PR DESCRIPTION
## Summary
- Fixed TypeError when progress is undefined on the progress screen
- Removed unsafe non-null assertion operator (!) on Progress.getProgress()
- Added null check before accessing progress properties
- Changed content type to allow undefined when progress is missing

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/3743/occurrence/454356249469

## Decision
This was fixed because it affects the core workout tracking functionality.

## Root Cause
The error occurred when the app was on the "progress" screen but `Progress.getProgress(state)` returned undefined. The code used the non-null assertion operator (`!`) assuming progress would always exist on the progress screen, but there are edge cases (likely related to the user editing and saving the program mid-workout) where progress can be undefined or invalidated. When this happens, calling `Progress.isCurrent(progress)` with undefined causes a TypeError.

From the telemetry, the user:
1. Started a workout
2. Deleted sets and made changes
3. Switched to the "Edit" tab
4. Saved the program
5. Navigated back
6. Then encountered the error

This sequence suggests that saving the program during an active workout may clear or invalidate the progress state temporarily.

## Test plan
- [x] TypeScript compilation passes
- [x] ESLint passes
- [x] All unit tests pass (247 passing)
- [x] Playwright E2E tests pass (32/33, subscriptions.spec.ts flaky as expected)
