### PR TITLE
fix-rollbar (4986/454427841616): Prevent lens error when editProgramExercise screen missing

### DIFF
--- a/src/components/editProgramExercise/screenEditProgramExercise.tsx
+++ b/src/components/editProgramExercise/screenEditProgramExercise.tsx
@@ -260,21 +260,24 @@ export function ScreenEditProgramExercise(props: IProps): JSX.Element {
               pickerDispatch={buildCustomLensDispatch(plannerDispatch, lbUi.pi("exercisePickerState"))}
               dispatch={props.dispatch}
               onNewKey={(newKey) => {
-                updateState(
-                  props.dispatch,
-                  [
-                    (
-                      lb<IState>().p("screenStack").findBy("name", "editProgramExercise").p("params") as LensBuilder<
-                        IState,
-                        { key: string },
-                        {}
-                      >
-                    )
-                      .pi("key")
-                      .record(newKey),
-                  ],
-                  "Update exercise key in screen params"
-                );
+                const hasEditExerciseScreen = props.navCommon.screenStack.some((s) => s.name === "editProgramExercise");
+                if (hasEditExerciseScreen) {
+                  updateState(
+                    props.dispatch,
+                    [
+                      (
+                        lb<IState>().p("screenStack").findBy("name", "editProgramExercise").p("params") as LensBuilder<
+                          IState,
+                          { key: string },
+                          {}
+                        >
+                      )
+                        .pi("key")
+                        .record(newKey),
+                    ],
+                    "Update exercise key in screen params"
+                  );
+                }
               }}
             />
           )}

--- a/src/ducks/reducer.ts
+++ b/src/ducks/reducer.ts
@@ -396,7 +396,8 @@ export function defaultOnActions(env: IEnv): IReducerOnAction[] {
             newState.storage.settings
           );
           const newKey = changedKeys[oldExerciseKey];
-          if (newKey) {
+          const editExerciseScreen = newState.screenStack.find((s) => s.name === "editProgramExercise");
+          if (newKey && editExerciseScreen) {
             updateState(
               dispatch,
               [
@@ -650,11 +651,7 @@ export const reducer: Reducer<IState, IAction> = (state, action): IState => {
     }
     return Progress.setProgress(
       state,
-      buildCardsReducer(
-        state.storage.settings,
-        state.storage.stats,
-        state.storage.subscription
-      )(progress, action)
+      buildCardsReducer(state.storage.settings, state.storage.stats, state.storage.subscription)(progress, action)
     );
   } else if (action.type === "StartProgramDayAction") {
     const progress = Progress.getProgress(state);


### PR DESCRIPTION
## Summary
- Added guard check in reducer middleware to ensure editProgramExercise screen exists before accessing via findBy
- Added guard check in screenEditProgramExercise onNewKey callback to prevent accessing screen params when screen is missing
- Prevents 'Cannot read properties of undefined (reading params)' lens errors when screen is popped while callbacks are pending

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/4986/occurrence/454427841616

## Decision
This was fixed. The error occurs when the editProgramExercise screen is removed from the screenStack (via navigation or FallbackScreen redirect) but callbacks still attempt to access it via lens findBy operations.

## Root Cause
The lens-shmens findBy() method returns undefined when the screen is not found in screenStack. Attempting to access .p('params') on undefined causes a TypeError. This can happen in two scenarios:
1. Reducer middleware (line 404) - During undo/redo operations, though no undo/redo was in the error case
2. Component callbacks (lines 43, 267) - When callbacks execute after screen is popped, most likely via the onNewKey callback when user interacts with exercise picker

The user was on the progress screen when the error occurred (screenStack only contained progress), suggesting the editProgramExercise screen was pushed, then quickly popped (possibly by FallbackScreen detecting invalid params), but a callback still attempted to update the screen params.

## Test plan
- [x] Built successfully (npm run build:prepare)
- [x] TypeScript compilation passed (tsc --noEmit)
- [x] Linting passed (npm run lint - existing unrelated errors in aihelpers)
- [x] All unit tests passed (248 passing)
- [x] Playwright E2E tests passed (30 passed, 3 flaky unrelated to changes)
- [x] Verified fix prevents lens errors by checking screen existence before findBy access