### PR TITLE
fix-rollbar (6039/454426019465): Handle undefined progress in workout screen

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -408,26 +408,32 @@ export function AppView(props: IProps): JSX.Element | null {
       throw new Error("Program is not selected on the 'main' screen");
     }
   } else if (Screen.currentName(state.screenStack) === "progress") {
-    const progress = Progress.getProgress(state)!;
-    const program = Progress.isCurrent(progress)
-      ? Program.getFullProgram(state, progress.programId) ||
-        (currentProgram ? Program.fullProgram(currentProgram, state.storage.settings) : undefined)
+    const progress = Progress.getProgress(state);
+    const program = progress
+      ? Progress.isCurrent(progress)
+        ? Program.getFullProgram(state, progress.programId) ||
+          (currentProgram ? Program.fullProgram(currentProgram, state.storage.settings) : undefined)
+        : undefined
       : undefined;
     content = (
-      <ScreenWorkout
-        navCommon={navCommon}
-        stats={state.storage.stats}
-        helps={state.storage.helps}
-        history={state.storage.history}
-        subscription={state.storage.subscription}
-        userId={state.user?.id}
-        progress={progress}
-        allPrograms={state.storage.programs}
-        program={program}
-        currentProgram={currentProgram}
-        dispatch={dispatch}
-        settings={state.storage.settings}
-      />
+      <FallbackScreen state={{ progress }} dispatch={dispatch}>
+        {({ progress: progress2 }) => (
+          <ScreenWorkout
+            navCommon={navCommon}
+            stats={state.storage.stats}
+            helps={state.storage.helps}
+            history={state.storage.history}
+            subscription={state.storage.subscription}
+            userId={state.user?.id}
+            progress={progress2}
+            allPrograms={state.storage.programs}
+            program={program}
+            currentProgram={currentProgram}
+            dispatch={dispatch}
+            settings={state.storage.settings}
+          />
+        )}
+      </FallbackScreen>
     );
   } else if (Screen.currentName(state.screenStack) === "settings") {
     content = (


### PR DESCRIPTION
## Summary
- Added defensive check using FallbackScreen when progress is undefined
- Removed unsafe non-null assertion operator from Progress.getProgress()
- Ensures the app gracefully redirects to main screen when workout data is missing

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6039/occurrence/454426019465

## Decision
This error was worth fixing because it occurs in production and affects the core workout screen functionality.

## Root Cause
The code used a non-null assertion operator (!) on Progress.getProgress(state), which can return undefined during state transitions or race conditions (e.g., when rapidly navigating between program editor tabs). When progress was undefined, trying to access progress.ui caused the error.

## Test plan
- [x] TypeScript compilation passes
- [x] Lint passes
- [x] All unit tests pass (248 passing)
- [x] Playwright E2E tests pass (31/33, with 2 known flaky subscription tests)