### PR TITLE
fix-rollbar (4990/454291448003): guard against stale blur dispatches after edit set modal save

### DIFF
--- a/src/components/bottomSheetEditTarget.tsx
+++ b/src/components/bottomSheetEditTarget.tsx
@@ -47,11 +47,15 @@ function BottomSheetEditTargetContent(props: IBottomSheetEditTargetContentProps)
                 width={2.5}
                 name="target-minreps"
                 onBlur={(value) => {
-                  if (savedRef.current) return;
+                  if (savedRef.current) {
+                    return;
+                  }
                   updateProgress(props.dispatch, [lbSet.p("minReps").record(value)], "target-blur-minreps");
                 }}
                 onInput={(value) => {
-                  if (savedRef.current) return;
+                  if (savedRef.current) {
+                    return;
+                  }
                   if (value != null && !isNaN(value) && value >= 0) {
                     updateProgress(props.dispatch, [lbSet.p("minReps").record(value)], "target-input-minreps");
                   }
@@ -68,11 +72,15 @@ function BottomSheetEditTargetContent(props: IBottomSheetEditTargetContentProps)
                 width={2.5}
                 name="target-maxreps"
                 onBlur={(value) => {
-                  if (savedRef.current) return;
+                  if (savedRef.current) {
+                    return;
+                  }
                   updateProgress(props.dispatch, [lbSet.p("reps").record(value)], "target-blur-maxreps");
                 }}
                 onInput={(value) => {
-                  if (savedRef.current) return;
+                  if (savedRef.current) {
+                    return;
+                  }
                   if (value == null || (!isNaN(value) && value >= 0)) {
                     updateProgress(props.dispatch, [lbSet.p("reps").record(value)], "target-input-maxreps");
                   }
@@ -110,7 +118,9 @@ function BottomSheetEditTargetContent(props: IBottomSheetEditTargetContentProps)
                 subscription={props.subscription}
                 exerciseType={props.editSetModal.exerciseType}
                 onBlur={(value) => {
-                  if (savedRef.current) return;
+                  if (savedRef.current) {
+                    return;
+                  }
                   updateProgress(
                     props.dispatch,
                     [lbSet.p("originalWeight").record(value ?? Weight.build(0, "lb"))],
@@ -118,7 +128,9 @@ function BottomSheetEditTargetContent(props: IBottomSheetEditTargetContentProps)
                   );
                 }}
                 onInput={(value) => {
-                  if (savedRef.current) return;
+                  if (savedRef.current) {
+                    return;
+                  }
                   if (value != null) {
                     updateProgress(
                       props.dispatch,
@@ -180,11 +192,15 @@ function BottomSheetEditTargetContent(props: IBottomSheetEditTargetContentProps)
                   width={2.5}
                   name="target-rpe"
                   onBlur={(value) => {
-                    if (savedRef.current) return;
+                    if (savedRef.current) {
+                      return;
+                    }
                     updateProgress(props.dispatch, [lbSet.p("rpe").record(value)], "target-blur-rpe");
                   }}
                   onInput={(value) => {
-                    if (savedRef.current) return;
+                    if (savedRef.current) {
+                      return;
+                    }
                     if (value != null && !isNaN(value) && value >= 0) {
                       updateProgress(props.dispatch, [lbSet.p("rpe").record(value)], "target-input-rpe");
                     }
@@ -250,11 +266,15 @@ function BottomSheetEditTargetContent(props: IBottomSheetEditTargetContentProps)
                   width={2.5}
                   name="target-timer"
                   onBlur={(value) => {
-                    if (savedRef.current) return;
+                    if (savedRef.current) {
+                      return;
+                    }
                     updateProgress(props.dispatch, [lbSet.p("timer").record(value)], "target-blur-timer");
                   }}
                   onInput={(value) => {
-                    if (savedRef.current) return;
+                    if (savedRef.current) {
+                      return;
+                    }
                     if (value != null && !isNaN(value) && value >= 0) {
                       updateProgress(props.dispatch, [lbSet.p("timer").record(value)], "target-input-timer");
                     }


### PR DESCRIPTION
## Summary
- Add `savedRef` guard in `BottomSheetEditTargetContent` to prevent `onBlur`/`onInput` callbacks from dispatching state updates after the Save button has been clicked
- When Save is clicked, `editSetModal` is set to `undefined` in state, but async blur events (10ms `setTimeout` in `InputNumber2`) can still fire and try to update through the now-undefined lens path
- All early return statements properly wrapped in curly braces per linter requirements

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/4990/occurrence/454291448003

## Decision
Fixed because this is a real error affecting normal user flows — editing set targets and clicking Save triggers a LensError when the blur fires after the modal state is cleared.

## Root Cause
When a user clicks the Save button in the Edit Set Target modal, two things happen in sequence:
1. The save handler sets `editSetModal` to `undefined` in the progress state
2. The input blur event fires asynchronously (via `setTimeout` with 10ms delay in `InputNumber2`) and tries to dispatch an `UpdateProgress` action through `lbSet.p("originalWeight")`, where `lbSet` includes the path `ui.editSetModal.set` — but `editSetModal` is already `undefined`, causing the lens to throw

The telemetry shows the user clicked the Save button (the purple card button) rapidly, which triggered the blur on the weight input after the modal was already dismissed.

## Test plan
- [x] Start a workout, complete a set, click edit on a set
- [x] Edit the weight value, then click Save — verify it saves correctly
- [x] Rapidly double-click Save while weight input is focused — verify no error
- [x] Unit tests pass (247/247)
- [x] Playwright E2E tests pass (32/33, only known flaky `subscriptions.spec.ts` fails)
- [x] Build passes
- [x] TypeScript type check passes
- [x] ESLint passes with no errors

## Changes from original PR #410
- Addressed linter feedback: all early return statements now properly wrapped in curly braces