### PR TITLE
fix-rollbar (6043/454485515388): Prevent io-ts validation error on program import

### DIFF
--- a/src/ducks/thunks.ts
+++ b/src/ducks/thunks.ts
@@ -1098,8 +1098,12 @@ export namespace Thunk {
       const result = await ImportExporter.getExportedProgram(env.service.client, maybeProgram, state.storage.settings);
       if (result.success) {
         const { program, customExercises } = result.data;
-        program.source = source || undefined;
-        program.authorid = userid || undefined;
+        if (source) {
+          program.source = source;
+        }
+        if (userid) {
+          program.authorid = userid;
+        }
         const newProgram: IProgram = { ...ObjectUtils.clone(program), clonedAt: Date.now() };
         if (!confirm(`Do you want to import program ${newProgram.name}?`)) {
           return;


### PR DESCRIPTION
## Summary
- Fixed io-ts validation error when importing programs without source or authorid
- Changed from explicitly setting fields to undefined to conditionally setting them only when values exist

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6043/occurrence/454485515388

## Decision
This error was worth fixing. It's a legitimate bug in our code that affects normal users importing programs via links.

## Root Cause
When importing a program via link, if the URL doesn't contain source (`s`) or userid (`u`) query parameters, the code was explicitly setting `program.source` and `program.authorid` to `undefined`.

In io-ts, fields defined as `t.partial` should either be omitted entirely or have a valid value. Explicitly setting them to `undefined` fails validation because io-ts doesn't consider `undefined` as a valid value for optional fields - the field should simply be absent from the object.

The error path was:
1. User imports a program from a link without `s` or `u` params
2. `importFromLink` returns `source: undefined` and `userid: undefined`
3. `importProgram` thunk sets `program.source = source || undefined` (line 1101)
4. When the program is saved to storage, io-ts validation runs and fails because `source` is explicitly `undefined`

## Test plan
- [x] Build succeeded
- [x] TypeScript compilation passed
- [x] Linting passed  
- [x] Unit tests passed (248 passing)
- [x] Playwright E2E tests ran (31 passed, 1 flaky subscription test - expected, 1 failed preview test - unrelated)