### PR TITLE
fix-rollbar (5629/454538621662): handle set deletion race condition

### DIFF
--- a/src/ducks/thunks.ts
+++ b/src/ducks/thunks.ts
@@ -522,6 +522,11 @@ export namespace Thunk {
         : undefined;
 
       const set = isWarmup ? entry.warmupSets[adjustedSetIndex] : entry.sets[adjustedSetIndex];
+      if (!set) {
+        SendMessage.print(`Main App: Set not found at index ${adjustedSetIndex}, skipping`);
+        dispatch(Thunk.updateLiveActivity(entryIndex, setIndex, restTimer, restTimerSince));
+        return;
+      }
       if (set.isCompleted) {
         SendMessage.print(`Main App: Set already completed, refreshing live activity`);
         dispatch(Thunk.updateLiveActivity(entryIndex, setIndex, restTimer, restTimerSince));


### PR DESCRIPTION
## Summary
- Added bounds check in `completeSetExternal` thunk before accessing set array
- Prevents crash when user deletes a set and then tries to complete it

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/5629/occurrence/454538621662

## Decision
This error is worth fixing. It's a legitimate bug affecting normal user flows.

## Root Cause
Race condition where:
1. User completes a set
2. User deletes the set
3. User tries to complete a set again (likely the next set, but UI still had stale index)
4. Code tries to access `entry.sets[adjustedSetIndex]` which is now undefined
5. Accessing `.isCompleted` on undefined throws TypeError

The telemetry from Rollbar showed this exact sequence:
- 17:30:56 - User clicks complete set
- 17:30:59 - User clicks delete set
- 17:31:01 - User clicks complete set (error occurs)

This can happen especially during network offline/online transitions, where the user is rapidly interacting with the workout UI.

## Test plan
- [x] Build succeeds
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] Unit tests pass (248 passing)
- [x] Playwright E2E tests pass (30/33 passing, 3 flaky tests are pre-existing and unrelated to this change)