### PR TITLE
fix-rollbar (4163/454532008897): ignore CodeMirror invalid change range errors

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -37,6 +37,7 @@ export const exceptionIgnores = [
   '{"isTrusted":true}',
   "Unable to resolve host",
   "connection closed",
+  "Invalid change range",
 ];
 
 export namespace RollbarUtils {


### PR DESCRIPTION
## Summary
- Added "Invalid change range" to the exception ignore list to filter out CodeMirror library errors

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/4163/occurrence/454532008897

## Decision
This error was added to the ignore list rather than fixed because:
- It's an internal CodeMirror library bug, not our code
- The error originates from the CodeMirror EditContext API handling text input
- The error manifests as negative range values (e.g., -47 to -46) which are invalid
- Multiple errors fire in rapid succession (12+ errors in ~3 seconds), indicating a library-level issue
- This appears to be related to browser/mobile input quirks that cannot be controlled from application code

## Root Cause
The error occurs in CodeMirror's text update handler when the EditContext API (used for mobile text input) reports invalid negative change ranges. This is likely triggered by specific browser autocorrect/predictive text interactions on mobile devices that confuse CodeMirror's change tracking.

## Test plan
- [x] Build succeeds
- [x] TypeScript compilation passes
- [x] Lint passes for the changed file
- [x] Unit tests pass (248 passing)
- [x] Playwright E2E tests run (31 passed, 1 flaky unrelated, 1 known flaky subscription test)