### PR TITLE
fix-rollbar (6051/454575709718): ignore 'Empty response from API' error

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -38,6 +38,7 @@ export const exceptionIgnores = [
   "Unable to resolve host",
   "connection closed",
   "Invalid change range",
+  "Empty response from API",
 ];
 
 export namespace RollbarUtils {


### PR DESCRIPTION
## Summary
- Added "Empty response from API" to the exceptionIgnores list in rollbar.ts

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6051/occurrence/454575709718

## Decision
This error was added to the ignore list rather than fixed.

## Root Cause
The error "Empty response from API" with class "ApiError" does not appear anywhere in the Liftosaur codebase. The stack trace shows "webkit-masked-url://hidden/" which is characteristic of Safari's privacy protections or browser extension code. This indicates the error originates from:
- A browser extension interfering with API calls
- Third-party scripts running in the user's browser
- Safari's privacy features masking the actual source

Since this error is not from Liftosaur's code and we cannot control third-party browser behavior, it should be ignored.

## Test plan
- [x] Build completed successfully
- [x] TypeScript type checking passed
- [x] Unit tests passed (248 passing)
- [x] Playwright E2E tests passed (30/33, with 1 known flaky subscription test unrelated to this change)