### PR TITLE
fix-rollbar (6070/454741194529): fix RangeError on invalid browser locale

### DIFF
--- a/aihelpers/rollbar/rollbar-orchestrator.ts
+++ b/aihelpers/rollbar/rollbar-orchestrator.ts
@@ -418,7 +418,7 @@ async function main(): Promise<void> {
 
     while (batch.length < 10 && itemIndex < items.length) {
       const item = items[itemIndex];
-      itemIndex++;
+      itemIndex += 1;
 
       const occurrence = await getOccurrenceForItem(item.id);
       if (!occurrence) {

--- a/src/allExercises.tsx
+++ b/src/allExercises.tsx
@@ -1,3 +1,4 @@
+import "./localePolyfill";
 import { h } from "preact";
 import { PageWrapper } from "./components/pageWrapper";
 import { AllExercisesContent, IAllExercisesContentProps } from "./pages/allExercises/allExercisesContent";

--- a/src/exercise.tsx
+++ b/src/exercise.tsx
@@ -1,3 +1,4 @@
+import "./localePolyfill";
 import { h } from "preact";
 import { IExerciseContentProps, ExerciseContent } from "./pages/exercise/exerciseContent";
 import { HydrateUtils } from "./utils/hydrate";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import "./localePolyfill";
 import { h, render } from "preact";
 import RB from "rollbar";
 import { RollbarUtils } from "./utils/rollbar";

--- a/src/localePolyfill.ts
+++ b/src/localePolyfill.ts
@@ -1,0 +1,11 @@
+if (typeof navigator !== "undefined" && navigator.language) {
+  const originalLanguage = navigator.language;
+  const sanitizedLanguage = originalLanguage.replace(/@.*$/, "");
+
+  if (originalLanguage !== sanitizedLanguage) {
+    Object.defineProperty(navigator, "language", {
+      get: () => sanitizedLanguage,
+      configurable: true,
+    });
+  }
+}

--- a/src/planner.tsx
+++ b/src/planner.tsx
@@ -1,3 +1,4 @@
+import "./localePolyfill";
 import { h } from "preact";
 import { PageWrapper } from "./components/pageWrapper";
 import { IPlannerContentProps, PlannerContent } from "./pages/planner/plannerContent";

--- a/src/programDetails.tsx
+++ b/src/programDetails.tsx
@@ -1,3 +1,4 @@
+import "./localePolyfill";
 import { h } from "preact";
 import { PageWrapper } from "./components/pageWrapper";
 import { AudioInterface } from "./lib/audioInterface";

--- a/src/record.tsx
+++ b/src/record.tsx
@@ -1,3 +1,4 @@
+import "./localePolyfill";
 import { h } from "preact";
 import { RecordContent } from "./pages/record/recordContent";
 import { IRecordResponse } from "./api/service";

--- a/src/user.tsx
+++ b/src/user.tsx
@@ -1,3 +1,4 @@
+import "./localePolyfill";
 import { h } from "preact";
 import { HydrateUtils } from "./utils/hydrate";
 import { UserContent } from "./pages/user/userContent";


### PR DESCRIPTION
## Summary
- Added locale polyfill to sanitize navigator.language before UPlot initialization
- Strips invalid locale modifiers (anything after @) to prevent RangeError
- Applied polyfill to all entry points that load UPlot (allexercises, exercise, index, planner, programDetails, record, user)
- Fixed unrelated lint error in rollbar-orchestrator.ts

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6070/occurrence/454741194529

## Decision
This error is worth fixing because it affects users with certain browser configurations and blocks them from using graph features.

## Root Cause
The browser reported navigator.language as "en-US@posix", which is not a valid BCP 47 locale tag. UPlot library creates an Intl.NumberFormat at module initialization time using navigator.language, which throws RangeError with invalid locale strings.

Some browsers (especially older versions) can report malformed locale strings with @ modifiers that are not part of the standard locale format.

## Test plan
- [x] Build passes
- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] Unit tests pass (248 tests)
- [x] Playwright E2E tests pass for all graph-related tests (exerciseStats, graphSelector, muscleGroups, stats)
- [x] Verified the polyfill correctly strips @ modifiers from navigator.language