### PR TITLE
fix-rollbar (6078/454737649215): Handle undefined settings when importing programs

### DIFF
--- a/aihelpers/rollbar/rollbar-orchestrator.ts
+++ b/aihelpers/rollbar/rollbar-orchestrator.ts
@@ -418,7 +418,7 @@ async function main(): Promise<void> {
 
     while (batch.length < 10 && itemIndex < items.length) {
       const item = items[itemIndex];
-      itemIndex++;
+      itemIndex += 1;
 
       const occurrence = await getOccurrenceForItem(item.id);
       if (!occurrence) {

--- a/src/api/service.ts
+++ b/src/api/service.ts
@@ -580,8 +580,6 @@ export class Service {
     }
   }
 
-
-
   public async programsIndex(): Promise<IProgramIndexEntry[]> {
     const response = await this.client(`${__HOST__}/programdata/index.json`);
     return response.json();

--- a/src/ducks/thunks.ts
+++ b/src/ducks/thunks.ts
@@ -887,7 +887,6 @@ export namespace Thunk {
     };
   }
 
-
   export function fetchPrograms(): IThunk {
     return async (dispatch, getState, env) => {
       const programs = await load(dispatch, "Loading programs", async () => {

--- a/src/lib/importexporter.ts
+++ b/src/lib/importexporter.ts
@@ -45,8 +45,8 @@ export namespace ImportExporter {
     }
     const payload = Storage.getDefault();
     payload.settings = ObjectUtils.clone(settings || payload.settings);
-    payload.settings.timers.workout = exportedProgram.settings.timers?.workout || payload.settings.timers.workout;
-    payload.settings.units = exportedProgram.settings.units || payload.settings.units;
+    payload.settings.timers.workout = exportedProgram.settings?.timers?.workout || payload.settings.timers.workout;
+    payload.settings.units = exportedProgram.settings?.units || payload.settings.units;
     payload.settings.exercises = exportedProgram.customExercises;
     payload.programs.push(exportedProgram.program);
     payload.version = exportedProgram.version;


### PR DESCRIPTION
## Summary
- Added optional chaining to safely access `exportedProgram.settings` when importing programs
- Fixed lint error (unary operator) in rollbar-orchestrator.ts
- Fixed ESLint whitespace issues

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6078/occurrence/454737649215

## Decision
This error should be FIXED as it blocks users from importing certain programs, which is a core feature of Liftosaur.

## Root Cause
When importing a program from JSON, `exportedProgram.settings` can be `undefined` because `IProgramContentSettings` is a `Partial` type. The code was accessing `exportedProgram.settings.timers` and `exportedProgram.settings.units` without checking if `settings` itself exists first, causing a TypeError: "undefined is not an object (evaluating 'i.settings.timers')".

The user repeatedly tried to import a program (3 times in the error logs), and each attempt failed with the same error.

## Test plan
- [x] Build completes successfully
- [x] TypeScript compilation passes with no errors
- [x] ESLint passes with no errors
- [x] All 248 unit tests pass
- [x] Playwright E2E tests run (2 pre-existing flaky tests unrelated to changes)
