### PR TITLE
fix-rollbar (6043/454811524427): Fix undefined planner field in copied programs

### DIFF
--- a/src/pages/program/programContentList.tsx
+++ b/src/pages/program/programContentList.tsx
@@ -125,7 +125,7 @@ export function ProgramContentList(props: IProgramContentListProps): JSX.Element
                         name: newName,
                         id: UidFactory.generateUid(8),
                         clonedAt: Date.now(),
-                        planner: program.planner ? { ...program.planner, name: newName } : undefined,
+                        ...(program.planner ? { planner: { ...program.planner, name: newName } } : {}),
                       };
                       try {
                         await saveProgram(newProgram, props.service);


### PR DESCRIPTION
## Summary
- Fixed validation error when copying programs without planner
- Changed program copy logic to omit planner field instead of setting it to undefined

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6043/occurrence/454811524427

## Decision
Fixed - this is a real bug affecting users who copy programs

## Root Cause
When copying a program in programContentList.tsx, the code was creating a new program object with `planner: program.planner ? { ...program.planner, name: newName } : undefined`. If the original program didn't have a planner, this explicitly set `planner: undefined` in the new object.

The TProgram type has `planner` in a `t.partial`, which means the field should either be absent OR be a valid TPlannerProgram, but NOT explicitly undefined. io-ts validation fails when a partial field is explicitly set to undefined.

## Test plan
- [x] Build and lint pass
- [x] All unit tests pass (248 passing)
- [x] Playwright E2E tests pass (31/33 - 2 flaky tests unrelated to this fix)