### PR TITLE
fix-rollbar (4726/454808091702): Ignore Instagram in-app browser autofill error

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -40,6 +40,7 @@ export const exceptionIgnores = [
   "connection closed",
   "Invalid change range",
   "Empty response from API",
+  "_AutofillCallbackHandler",
 ];
 
 export namespace RollbarUtils {


### PR DESCRIPTION
## Summary
- Added `_AutofillCallbackHandler` to Rollbar exception ignore list

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/4726/occurrence/454808091702

## Decision
This error was added to the ignore list because it originates from Instagram's in-app browser and is not actionable.

## Root Cause
Instagram's in-app browser injects autofill scripts into web pages. The error `ReferenceError: Can't find variable: _AutofillCallbackHandler` occurs when Instagram's injected code tries to access a variable that doesn't exist. This happens at the global scope (line 1 of the page) before our application code runs, and is entirely within Instagram's WebView implementation.

## Test plan
- [x] Build passes
- [x] TypeScript compilation succeeds
- [x] Lint passes
- [x] Unit tests pass
- [x] Playwright E2E tests run (some pre-existing flaky tests unrelated to this change)