### PR TITLE
fix-rollbar (5888/454803221482): Remove undefined values before storage validation

### DIFF
--- a/src/models/storage.ts
+++ b/src/models/storage.ts
@@ -59,15 +59,16 @@ export namespace Storage {
     type: t.Type<any, any, any>,
     name: string
   ): IEither<IStorage, string[]> {
-    const result = validate(data, type, name);
+    const cleanedData = ObjectUtils.removeUndefined(data);
+    const result = validate(cleanedData, type, name);
     if (!result.success) {
       const error = result.error;
       lg("ls-corrupted-storage", { lastActions: JSON.stringify(window.reducerLastActions || []) });
       if (Rollbar != null) {
-        Rollbar.error(error.join("\n"), { state: JSON.stringify(data), type: name });
+        Rollbar.error(error.join("\n"), { state: JSON.stringify(cleanedData), type: name });
       }
       console.error(`Error decoding ${name}`);
-      console.log(data);
+      console.log(cleanedData);
       error.forEach((e) => console.error(e));
     }
     return result;

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -239,4 +239,25 @@ export namespace ObjectUtils {
       {} as Record<K, V>
     );
   }
+
+  export function removeUndefined<T>(obj: T): T {
+    if (obj == null || typeof obj !== "object") {
+      return obj;
+    }
+
+    if (Array.isArray(obj)) {
+      return obj.map((item) => removeUndefined(item)) as any;
+    }
+
+    const result: any = {};
+    for (const key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        const value = obj[key];
+        if (value !== undefined) {
+          result[key] = removeUndefined(value);
+        }
+      }
+    }
+    return result;
+  }
 }


### PR DESCRIPTION
## Summary
- Added `ObjectUtils.removeUndefined()` utility function to recursively remove explicit `undefined` values from objects
- Updated `Storage.validateAndReport()` to clean data before validation using the new utility
- Fixes io-ts validation errors when optional fields are explicitly set to `undefined` instead of being omitted

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/5888/occurrence/454803221482

## Decision
This error was fixed. The validation error occurs when code explicitly sets optional fields to `undefined` (e.g., `timer: undefined`) instead of omitting them. The io-ts library's `t.partial` type expects optional fields to either have valid values or be completely absent, not explicitly set to `undefined`.

## Root Cause
Multiple places in the codebase explicitly set timer-related fields to `undefined` when clearing them:
- `src/models/progress.ts:469-473` and `722-726` - `stopTimerPure()` and timer clearing logic
- `src/models/history.ts:110-111` - converting progress to history record

When these objects reach validation in `validateAndReportStorage()`, io-ts fails because it sees explicit `undefined` values on optional fields.

## Test plan
- [x] Build succeeds
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] Unit tests pass (248 passing)
- [x] Playwright E2E tests (31 passing, 2 flaky failures unrelated to this change)