### PR TITLE
fix-rollbar (5576/454876116460): Always use DB programs in augmentLimitedUser

### DIFF
--- a/lambda/dao/userDao.ts
+++ b/lambda/dao/userDao.ts
@@ -160,9 +160,8 @@ export class UserDao {
         const storageUpdateProgram = storageUpdate.storage?.programs?.find((sup) => sup.id === p.id);
         return storageUpdateProgram && storageUpdateProgram.clonedAt === p.clonedAt;
       });
-      if (allClonedAtsAreDifferent && allProgramsValid) {
-        programs = storagePrograms;
-      } else {
+      programs = storagePrograms;
+      if (!allClonedAtsAreDifferent || !allProgramsValid) {
         const eventDao = new EventDao(this.di);
         await eventDao.post({
           type: "event",


### PR DESCRIPTION
## Summary
- Fixed augmentLimitedUser to always use programs fetched from DB, even when clonedAt validation fails
- This prevents corrupted_server_storage errors when Storage.get() validates storage and finds missing required fields

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/5576/occurrence/454876116460

## Decision
Fixed - this is a real bug causing sync failures for users.

## Root Cause
When augmentLimitedUser fetched programs from the database but the clonedAt validation failed (allClonedAtsAreDifferent || allProgramsValid check), it would log an event but not update the programs variable. This left the storage with potentially undefined or incomplete programs field, which then failed validation in Storage.get() because IStorage requires programs to be an array.

The bug was introduced when the validation logic was added to check clonedAt consistency, but the error handling didn't ensure that fetched data was still used even when validation failed.

## Test plan
- [x] Build succeeds
- [x] Type checks pass
- [x] Lint passes
- [x] Unit tests pass (250 passing)
- [x] Playwright E2E tests pass (30 passed, 2 pre-existing flaky failures unrelated to this change)