### PR TITLE
fix-rollbar (5318/454860976435): prevent crash when InputNumber unmounts

### DIFF
--- a/src/components/inputNumber.tsx
+++ b/src/components/inputNumber.tsx
@@ -19,6 +19,9 @@ export function InputNumber(props: IInputNumberProps): JSX.Element {
   const actualStep = step ?? 1;
 
   function getValue(): number | undefined {
+    if (!inputRef.current) {
+      return undefined;
+    }
     const inputValue = inputRef.current.value || min;
     const v = inputValue != null ? Number(inputValue) : undefined;
     if (v != null && !isNaN(v)) {


### PR DESCRIPTION
## Summary
- Add null check in InputNumber getValue() to prevent crash during unmount
- Fix affects InputNumber component used throughout the app (settings, workout editing, etc.)

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/5318/occurrence/454860976435

## Decision
This error is worth fixing. It affects normal user flows when navigating away from screens with number inputs.

## Root Cause
The error occurs when a user inputs a value into an InputNumber field and then navigates away (e.g., clicking back or switching screens) while the input is focused. The blur event fires during component unmount, at which point inputRef.current is null, causing the crash.

From the telemetry, we can see:
1. User input "2.5" into a number field at 17:19:50
2. User navigated back (go-back) immediately after
3. The blur handler tried to access inputRef.current.value but the ref was already null

## Test plan
- [x] Unit tests pass
- [x] TypeScript checks pass
- [x] Lint passes
- [x] Playwright E2E tests run (failures are unrelated to this fix)