### PR TITLE
fix-rollbar (6119/454995242340): handle non-string values in Markdown component

### DIFF
--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -44,7 +44,8 @@ interface IProps {
 export function Markdown(props: IProps): JSX.Element {
   const [shouldTruncate, setShouldTruncate] = useState(props.truncate != null);
   const [isTruncated, setIsTruncated] = useState(props.truncate != null);
-  const value = preprocessDirectives(props.value, props.directivesData);
+  const stringValue = typeof props.value === "string" ? props.value : String(props.value ?? "");
+  const value = preprocessDirectives(stringValue, props.directivesData);
   const result = md.render(value);
   let className = props.className || "markdown";
   if (isTruncated && props.className?.indexOf("line-clamp") === -1) {


### PR DESCRIPTION
## Summary
- Added defensive type check in Markdown component to handle non-string values
- Convert non-string values (null/undefined) to empty strings before passing to markdown-it renderer

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6119/occurrence/454995242340

## Decision
Fixed the error by adding a type guard to ensure the value passed to markdown-it is always a string.

## Root Cause
The Markdown component receives `props.value` which is typed as string but can be non-string at runtime (likely null/undefined from incomplete program index entries). The markdown-it library's `render()` method strictly requires a string and throws "Input data should be a String" when given other types.

The error occurred when viewing the built-in programs tab in settings, where program cards render `program.shortDescription` using the Markdown component.

## Test plan
- [x] Build succeeds
- [x] TypeScript check passes
- [x] ESLint passes
- [x] Unit tests pass (250 passing)
- [x] Playwright tests pass (29 passing, 2 pre-existing failures unrelated to this fix)