### PR TITLE
fix-rollbar (4847/454994216437): Guard against undefined week in EditProgramUiWeekView

### DIFF
--- a/src/components/editProgram/editProgramUiWeek.tsx
+++ b/src/components/editProgram/editProgramUiWeek.tsx
@@ -38,6 +38,10 @@ export function EditProgramUiWeekView(props: IEditProgramViewProps): JSX.Element
   const planner = program.planner!;
 
   const currentWeek = planner.weeks[currentWeekIndex];
+  if (!currentWeek) {
+    return <div></div>;
+  }
+
   const lbPlanner = lb<IPlannerState>().p("current").p("program").pi("planner");
   const lbUi = lb<IPlannerState>().p("ui");
   const lbPlannerWeek = lbPlanner.p("weeks").i(currentWeekIndex);


### PR DESCRIPTION
## Summary
- Added defensive guard in EditProgramUiWeekView to handle case where ui.weekIndex is out of bounds for planner.weeks array
- Returns empty div when currentWeek is undefined instead of crashing on property access

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/4847/occurrence/454994216437

## Decision
This was fixed because it's a legitimate bug affecting normal user flows in the program editor.

## Root Cause
The error occurred when the user was editing a program and the UI state `weekIndex` (set to 2) became out of sync with the actual number of weeks in `planner.weeks` (only had 1 week). This can happen during program modifications or when switching between editing modes. When the component tried to access `planner.weeks[2].days`, it crashed because `planner.weeks[2]` was `undefined`.

## Test plan
- [x] Build succeeds without errors
- [x] TypeScript compilation passes
- [x] ESLint passes
- [x] All unit tests pass (250 passing)
- [x] Playwright E2E tests run (28 passed, flaky failures unrelated to this fix)
