### PR TITLE
fix-rollbar (4507/454991003041): prevent appendChild null error in portal components

### DIFF
--- a/src/components/inputNumber2.tsx
+++ b/src/components/inputNumber2.tsx
@@ -421,7 +421,9 @@ interface ICustomKeyboardProps {
 }
 
 const CustomKeyboard = forwardRef((props: ICustomKeyboardProps, ref: RefObject<HTMLDivElement>) => {
-  return createPortal(
+  const containerRef = typeof window !== "undefined" ? window.document.querySelector("#keyboard") : undefined;
+
+  const element = (
     <div ref={ref} id="keyboard-content" className="fixed bottom-0 left-0 z-50 w-full keyboard-shadow">
       <div className="safe-area-inset-bottom">
         <div className="flex items-center w-full gap-2 px-4 bg-background-subtle">
@@ -534,7 +536,8 @@ const CustomKeyboard = forwardRef((props: ICustomKeyboardProps, ref: RefObject<H
           </div>
         </div>
       </div>
-    </div>,
-    document.querySelector("#keyboard")!
+    </div>
   );
+
+  return containerRef ? createPortal(element, containerRef) : element;
 });

--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -57,7 +57,9 @@ export function Modal(props: IProps): JSX.Element {
     }
   }
 
-  return createPortal(
+  const containerRef = typeof window !== "undefined" ? window.document.getElementById("modal") : undefined;
+
+  const element = (
     <section ref={modalRef} className={className} style={{ zIndex: props.zIndex ?? 40 }}>
       <div
         data-name="overlay"
@@ -94,7 +96,8 @@ export function Modal(props: IProps): JSX.Element {
           </button>
         )}
       </div>
-    </section>,
-    document.getElementById("modal")!
+    </section>
   );
+
+  return containerRef ? createPortal(element, containerRef) : element;
 }


### PR DESCRIPTION
## Summary
- Made Modal component defensive to prevent crashes when portal container doesn't exist yet
- Made CustomKeyboard component defensive to prevent crashes when portal container doesn't exist yet
- Both components now check if portal container exists before using createPortal, falling back to inline rendering

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/4507/occurrence/454991003041

## Decision
This was fixed because it's a real bug affecting production users on modern browsers.

## Root Cause
Race condition where users could click to open a modal/keyboard very quickly after page load (~1.8s in this case), before the Page component had fully rendered the portal containers (#modal, #keyboard). The components used non-null assertions (!) when calling document.getElementById(), causing Preact to crash when trying to call appendChild on null.

## Test plan
- [x] Build and type check passed
- [x] Lint passed
- [x] All unit tests passed (250 passing)
- [x] Playwright E2E tests ran (27 passed, failures unrelated to changes - test data and timeout issues)