### PR TITLE
fix-rollbar (4941/455028084268): Fix undefined evaluatedDay crash when adding planner day

### DIFF
--- a/src/pages/planner/components/plannerDay.tsx
+++ b/src/pages/planner/components/plannerDay.tsx
@@ -38,10 +38,10 @@ export function PlannerDay(props: IPlannerDayProps): JSX.Element {
   const { day, dispatch, lbProgram, weekIndex, dayIndex } = props;
   const { exercises } = props.settings;
   const focusedExercise = props.ui.focusedExercise;
-  const evaluatedDay = props.evaluatedWeeks[weekIndex][dayIndex];
+  const evaluatedDay = props.evaluatedWeeks[weekIndex]?.[dayIndex];
   const isFocused = focusedExercise?.weekIndex === weekIndex && focusedExercise?.dayIndex === dayIndex;
   let approxDayTime: string | undefined;
-  if (evaluatedDay.success) {
+  if (evaluatedDay?.success) {
     for (const plannerExercise of evaluatedDay.data) {
       const exercise = Exercise.findByName(plannerExercise.name, {});
       if (exercise) {
@@ -53,7 +53,7 @@ export function PlannerDay(props: IPlannerDayProps): JSX.Element {
     );
   }
   const showProgramDescription = day.description != null;
-  const repeats: IPlannerProgramExercise[] = evaluatedDay.success ? evaluatedDay.data.filter((e) => e.isRepeat) : [];
+  const repeats: IPlannerProgramExercise[] = evaluatedDay?.success ? evaluatedDay.data.filter((e) => e.isRepeat) : [];
 
   return (
     <div className="flex flex-col md:flex-row">
@@ -218,12 +218,12 @@ export function PlannerDay(props: IPlannerDayProps): JSX.Element {
         </div>
       </div>
       <div className="w-56 ml-0 sm:ml-4">
-        {isFocused && (
+        {isFocused && evaluatedDay && (
           <PlannerDayStats
             dispatch={dispatch}
             focusedExercise={focusedExercise}
             settings={props.settings}
-            evaluatedDay={props.evaluatedWeeks[props.weekIndex][props.dayIndex]}
+            evaluatedDay={evaluatedDay}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary
- Added optional chaining to safely access evaluatedDay in PlannerDay component
- Added check before rendering PlannerDayStats to ensure evaluatedDay exists
- Prevents crash when adding new days before evaluatedWeeks recalculates

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/4941/occurrence/455028084268

## Decision
This was fixed because it's a real bug affecting normal user flows in the planner.

## Root Cause
When a user clicks "Add Day" in the planner, a new day is added to the program's week.days array. During the render cycle, PlannerWeek maps over week.days to render each PlannerDay component. However, the evaluatedWeeks array (computed via useMemo) hasn't recalculated yet, so evaluatedWeeks[weekIndex][dayIndex] is undefined for the newly added day. The code tried to access .success on undefined, causing a TypeError.

## Test plan
- [x] Build completes successfully
- [x] TypeScript type checks pass
- [x] Linter passes
- [x] Unit tests pass (250 passing)
- [x] Playwright E2E tests pass (30 passing, 2 failures unrelated to this change)