### PR TITLE
fix-rollbar (2621/455022742646): Prevent Apple Sign In messages from crashing Google Sign In handler

### DIFF
--- a/src/utils/googleAccessToken.ts
+++ b/src/utils/googleAccessToken.ts
@@ -48,6 +48,9 @@ export function getGoogleAccessToken(): Promise<string | undefined> {
       if (typeof data !== "string") {
         return;
       }
+      if (!data.startsWith("http://") && !data.startsWith("https://")) {
+        return;
+      }
       const callbackUrl = UrlUtils_build(data);
       const params = callbackUrl.hash.slice(1);
       const exUrl = UrlUtils_build("https://www.example.com");


### PR DESCRIPTION
## Summary
- Added URL protocol validation in Google Sign In message handler to reject non-URL messages
- Prevents Apple Sign In OAuth completion messages from being processed as URLs

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/2621/occurrence/455022742646

## Decision
This error is worth fixing. It's a production error affecting the normal OAuth flow when users have both Google Sign In and Apple Sign In available.

## Root Cause
When Apple Sign In completes on iOS, it posts a message with JSON data `{"method":"oauthDone","data":{...}}` back to the web view. This message is being caught by the Google Sign In message handler at googleAccessToken.ts:46-57, which expects only URL strings from the Google OAuth callback.

The handler was checking if the data is a string (line 48-50) but then immediately tried to construct a URL from it (line 51), causing a TypeError when the string is JSON instead of a URL.

## Test plan
- [x] Build passes
- [x] TypeScript compilation passes
- [x] Linter passes
- [x] Unit tests pass (250 passing)
- [x] Playwright E2E tests pass (27 passing, 2 known flaky failures in unrelated tests)