### PR TITLE
fix-rollbar (6139/455108186563): fix lens error when navigating away from planner screens

### DIFF
--- a/src/components/editProgram/screenProgram.tsx
+++ b/src/components/editProgram/screenProgram.tsx
@@ -67,10 +67,11 @@ export function ScreenProgram(props: IProps): JSX.Element {
     buildPlannerDispatch(
       props.dispatch,
       (
-        lb<IState>().p("screenStack").findBy("name", "editProgram", true).p("params") as LensBuilder<
+        lb<IState>().p("screenStack").findBy("name", "editProgram", true).pi("params") as LensBuilder<
           IState,
           { plannerState: IPlannerState },
-          {}
+          {},
+          undefined
         >
       ).pi("plannerState"),
       plannerState

--- a/src/components/editProgramExercise/screenEditProgramExercise.tsx
+++ b/src/components/editProgramExercise/screenEditProgramExercise.tsx
@@ -40,10 +40,11 @@ export function ScreenEditProgramExercise(props: IProps): JSX.Element {
     buildPlannerDispatch(
       props.dispatch,
       (
-        lb<IState>().p("screenStack").findBy("name", "editProgramExercise", true).p("params") as LensBuilder<
+        lb<IState>().p("screenStack").findBy("name", "editProgramExercise", true).pi("params") as LensBuilder<
           IState,
           { plannerState: IPlannerExerciseState },
-          {}
+          {},
+          undefined
         >
       ).pi("plannerState"),
       plannerState
@@ -266,11 +267,10 @@ export function ScreenEditProgramExercise(props: IProps): JSX.Element {
                     props.dispatch,
                     [
                       (
-                        lb<IState>().p("screenStack").findBy("name", "editProgramExercise").p("params") as LensBuilder<
-                          IState,
-                          { key: string },
-                          {}
-                        >
+                        lb<IState>()
+                          .p("screenStack")
+                          .findBy("name", "editProgramExercise", true)
+                          .pi("params") as LensBuilder<IState, { key: string }, {}, undefined>
                       )
                         .pi("key")
                         .record(newKey),

--- a/src/ducks/reducer.ts
+++ b/src/ducks/reducer.ts
@@ -402,10 +402,11 @@ export function defaultOnActions(env: IEnv): IReducerOnAction[] {
               dispatch,
               [
                 (
-                  lb<IState>().p("screenStack").findBy("name", "editProgramExercise").p("params") as LensBuilder<
+                  lb<IState>().p("screenStack").findBy("name", "editProgramExercise", true).pi("params") as LensBuilder<
                     IState,
                     { key: string },
-                    {}
+                    {},
+                    undefined
                   >
                 )
                   .pi("key")


### PR DESCRIPTION
## Summary
- Fixed lens error when accessing screen params after navigation away from editProgramExercise
- Changed .p("params") to .pi("params") for optional parameter access
- Added undefined as fourth generic parameter to LensBuilder type casts
- Applied same fix to editProgram screen and reducer hook for consistency

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6139/occurrence/455108186563

## Decision
This error was fixed because it affects normal user flows when editing programs with the planner.

## Root Cause
When a user navigated away from the editProgramExercise or editProgram screen, any pending actions that used plannerDispatch would fail because the lens path tried to access params on a screen that no longer existed in the stack. The lens used findBy with the optional flag (true), but the subsequent .p("params") was not optional, causing it to fail when trying to read params from undefined.

## Test plan
- [x] TypeScript compilation passes
- [x] ESLint passes
- [x] All unit tests pass (250 tests)
- [x] Playwright E2E tests pass (29 passed, 1 flaky subscription test unrelated to changes)