### PR TITLE
fix-rollbar (6142/455096472226): handle undefined storage in getStorage

### DIFF
--- a/src/api/service.ts
+++ b/src/api/service.ts
@@ -424,10 +424,12 @@ export class Service {
     url.searchParams.set("historylimit", historylimit.toString());
     const result = await this.client(url.toString(), { credentials: "include" });
     const json = await result.json();
-    json.storage.history = await this.getAllHistoryRecords({
-      alreadyFetchedHistory: json.storage.history,
-      historyLimit: historylimit,
-    });
+    if (json.storage?.history) {
+      json.storage.history = await this.getAllHistoryRecords({
+        alreadyFetchedHistory: json.storage.history,
+        historyLimit: historylimit,
+      });
+    }
     return {
       email: json.email,
       storage: json.storage,


### PR DESCRIPTION
## Summary
- Added null check before accessing json.storage.history in Service.getStorage
- Prevents TypeError when API returns malformed or incomplete storage object

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6142/occurrence/455096472226

## Decision
Fixed - this is a legitimate bug affecting production users on iOS Safari 15.0

## Root Cause
When the API returns a response where `json.storage` is undefined (due to validation failures or malformed data), the code at line 428 tries to access `json.storage.history` without checking if `json.storage` exists first, causing a TypeError.

The Rollbar telemetry shows validation errors indicating missing required fields (`settings.gyms`, `settings.deletedGyms`), which resulted in the storage object being undefined or incomplete.

## Test plan
- [x] Build passes
- [x] TypeScript compilation passes
- [x] Lint passes
- [x] All unit tests pass (250 passing)
- [x] Playwright E2E tests run (30 passed, 2 flaky unrelated to this change, 1 known flaky subscription test)