### PR TITLE
fix-rollbar (5102/455087650205): add type guard for storage message events

### DIFF
--- a/src/utils/nativeStorage.ts
+++ b/src/utils/nativeStorage.ts
@@ -55,7 +55,7 @@ export class NativeStorage {
   constructor() {
     this.pendingRequests = new Map();
     window.addEventListener("message", (event) => {
-      if (event.data != null) {
+      if (event.data != null && this.isStorageResponse(event.data)) {
         this.handleResponse(event.data);
       }
     });
@@ -143,6 +143,22 @@ export class NativeStorage {
 
   private generateRequestId(): string {
     return `req_${UidFactory.generateUid(8)}`;
+  }
+
+  private isStorageResponse(data: unknown): data is IStorageResponse {
+    if (typeof data !== "object" || data === null) {
+      return false;
+    }
+    const obj = data as Record<string, unknown>;
+    return (
+      typeof obj.type === "string" &&
+      (obj.type === "storageGetResult" ||
+        obj.type === "storageSetResult" ||
+        obj.type === "storageDeleteResult" ||
+        obj.type === "storageHasResult" ||
+        obj.type === "storageGetAllKeysResult") &&
+      typeof obj.requestId === "string"
+    );
   }
 
   private handleResponse(data: IStorageResponse): void {


### PR DESCRIPTION
## Summary
- Added type guard `isStorageResponse()` to validate incoming window messages
- Modified event listener to check message type before processing
- Prevents null pointer errors when non-storage messages are received

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/5102/occurrence/455087650205

## Decision
This error was fixed because it affects the production Android app and occurs when the window message event listener receives messages from sources other than the native storage system (e.g., Google Analytics, browser APIs, or other scripts).

## Root Cause
The `NativeStorage` class listens to all window messages and attempts to process them as `IStorageResponse` objects. When other scripts post messages to the window (like Google Analytics, as seen in the telemetry), the code tried to access `data.requestId` on non-storage messages, causing a null pointer error.

The event listener checked if `event.data != null` but didn't validate that it was actually a storage response object before calling `handleResponse()`, which then tried to access `data.requestId` on line 149.

## Test plan
- [x] Build and type-check successful
- [x] ESLint passed
- [x] All 250 unit tests passed
- [x] Playwright E2E tests ran (2 pre-existing flaky failures unrelated to this change)