### PR TITLE
fix-rollbar (4/455169581698): Ignore Rollbar internal error

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -42,6 +42,7 @@ export const exceptionIgnores = [
   "Empty response from API",
   "_AutofillCallbackHandler",
   "Incorrect locale information provided",
+  "[unhandledrejection] error getting `reason` from event",
 ];
 
 export async function RollbarUtils_load(item: string | number, token: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Added `"[unhandledrejection] error getting 'reason' from event"` to the exception ignore list in `src/utils/rollbar.ts`

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/4/occurrence/455169581698

## Decision
This error was added to the ignore list because it is not actionable and does not originate from our code.

## Root Cause
This error is generated by Rollbar's error handling library itself when it fails to extract the rejection reason from a browser's unhandled promise rejection event. Based on the telemetry, this appears to be triggered by third-party scripts (Reddit pixel config, Google Analytics) that cause promise rejections Rollbar cannot properly access due to browser privacy/security restrictions or cross-origin issues.

The error has:
- No meaningful stack trace (filename: "(unknown)", no line numbers)
- No actionable information for fixing
- No impact on user functionality
- Cannot be fixed in our codebase (it's internal to Rollbar)

## Test plan
- [x] Build succeeds
- [x] TypeScript type checking passes
- [x] Linting passes
- [x] Unit tests pass (250 passing)
- [x] Playwright E2E tests run (29 passed, 2 flaky/timeout - unrelated to change)
