### PR TITLE
fix-rollbar (6120/455164783231): Handle non-string values in Markdown component

### DIFF
--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -45,7 +45,8 @@ export function Markdown(props: IProps): JSX.Element {
   const [shouldTruncate, setShouldTruncate] = useState(props.truncate != null);
   const [isTruncated, setIsTruncated] = useState(props.truncate != null);
   const stringValue = typeof props.value === "string" ? props.value : String(props.value ?? "");
-  const value = preprocessDirectives(stringValue, props.directivesData);
+  const preprocessed = preprocessDirectives(stringValue, props.directivesData);
+  const value = typeof preprocessed === "string" ? preprocessed : String(preprocessed ?? "");
   const result = md.render(value);
   let className = props.className || "markdown";
   if (isTruncated && props.className?.indexOf("line-clamp") === -1) {


### PR DESCRIPTION
## Summary
- Added defensive type checking in Markdown component to ensure value is always a string before rendering
- Prevents 'Input data should be a String' error when preprocessDirectives returns non-string values

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6120/occurrence/455164783231

## Decision
This error was fixed because it affects normal user flows when viewing built-in programs with malformed or missing shortDescription fields.

## Root Cause
The Markdown component receives props.value which gets converted to a string and passed through preprocessDirectives(). However, there was no guarantee that preprocessDirectives() would return a string type. When non-string values (like null, undefined, or malformed data from programdata/index.json) made it to md.render(), markdown-it threw the error 'Input data should be a String'.

The user was viewing the built-in programs list (clicked tab-built-in) when one of the program entries had a malformed or non-string shortDescription field.

## Test plan
- [x] Build passes
- [x] TypeScript type checker passes  
- [x] Linter passes
- [x] Unit tests pass (250 passing)
- [x] Playwright E2E tests pass (30 passed, 2 pre-existing failures unrelated to this change)