### PR TITLE
fix-rollbar (5572/455150109992): Invalid time value in Hevy CSV import

### DIFF
--- a/src/utils/importFromHevy.ts
+++ b/src/utils/importFromHevy.ts
@@ -366,11 +366,13 @@ export function ImportFromHevy_convertHevyCsvToHistoryRecords(
   const historyRecords: IHistoryRecord[] = hevyWorkouts.map((hevyWorkout) => {
     let startTs: number | undefined;
     try {
-      startTs = new Date(hevyWorkout.start_time).getTime();
+      const ts = new Date(hevyWorkout.start_time).getTime();
+      startTs = isNaN(ts) ? undefined : ts;
     } catch (_) {}
     let endTs: number | undefined;
     try {
-      endTs = new Date(hevyWorkout.end_time).getTime();
+      const ts = new Date(hevyWorkout.end_time).getTime();
+      endTs = isNaN(ts) ? undefined : ts;
     } catch (_) {}
     const entries = hevyWorkout.exercises.map((record, index) => {
       let exerciseNameAndEquipment = exerciseMapping[record.exercise_title];


### PR DESCRIPTION
## Summary
- Fixed handling of invalid timestamps when parsing Hevy CSV workout dates
- Added NaN check after Date.getTime() to prevent "Invalid time value" RangeError

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/5572/occurrence/455150109992

## Decision
This error was worth fixing because it affects users importing workout history from Hevy, a normal user flow. The error occurs in production and blocks the import process.

## Root Cause
When parsing Hevy CSV dates, the code calls `new Date(hevyWorkout.end_time).getTime()` which can return `NaN` for invalid date strings. The try-catch block doesn't catch this because getting `NaN` isn't an exception. Later, when the code calls `new Date(endTs).toISOString()` with `endTs` being `NaN`, it throws a RangeError because `NaN` creates an invalid Date object.

The fallback `endTs ?? Date.now()` doesn't work because `NaN` is truthy, so the fallback is never used.

## Test plan
- [x] Build and type checks pass
- [x] All unit tests pass (250 passing)
- [x] Playwright E2E tests run (subscription test failures are known flaky issues unrelated to this change)