### PR TITLE
fix-rollbar (6087/455146081992): handle null exerciseData in muscle multipliers migration

### DIFF
--- a/src/migrations/migrations.ts
+++ b/src/migrations/migrations.ts
@@ -319,15 +319,17 @@ export const migrations = {
   },
   "20260124114134_convert_muscle_multipliers_to_object": (aStorage: IStorage): IStorage => {
     const storage: IStorage = JSON.parse(JSON.stringify(aStorage));
-    for (const key of ObjectUtils.keys(storage.settings.exerciseData)) {
-      const exerciseData = storage.settings.exerciseData[key];
-      if (exerciseData?.muscleMultipliers && Array.isArray(exerciseData.muscleMultipliers)) {
-        const oldMultipliers = exerciseData.muscleMultipliers as Array<{ muscle: IMuscle; multiplier: number }>;
-        const newMultipliers: Partial<Record<IMuscle, number>> = {};
-        for (const mm of oldMultipliers) {
-          newMultipliers[mm.muscle] = mm.multiplier;
+    if (storage.settings.exerciseData) {
+      for (const key of ObjectUtils.keys(storage.settings.exerciseData)) {
+        const exerciseData = storage.settings.exerciseData[key];
+        if (exerciseData?.muscleMultipliers && Array.isArray(exerciseData.muscleMultipliers)) {
+          const oldMultipliers = exerciseData.muscleMultipliers as Array<{ muscle: IMuscle; multiplier: number }>;
+          const newMultipliers: Partial<Record<IMuscle, number>> = {};
+          for (const mm of oldMultipliers) {
+            newMultipliers[mm.muscle] = mm.multiplier;
+          }
+          exerciseData.muscleMultipliers = newMultipliers;
         }
-        exerciseData.muscleMultipliers = newMultipliers;
       }
     }
     return storage;


### PR DESCRIPTION
## Summary
- Added null/undefined check for `storage.settings.exerciseData` before calling `ObjectUtils.keys()` in the `20260124114134_convert_muscle_multipliers_to_object` migration
- This prevents the error "Cannot convert undefined or null to object" when the migration runs on storage that doesn't have exerciseData initialized

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6087/occurrence/455146081992

## Decision
This was a legitimate bug that needed fixing. The error caused a white screen (complete app failure) by breaking the migration process during app initialization.

## Root Cause
The migration `20260124114134_convert_muscle_multipliers_to_object` attempted to iterate over `storage.settings.exerciseData` without checking if it exists. For users who had old storage data without this field initialized, `ObjectUtils.keys()` would call `Object.keys()` on undefined/null, throwing "Cannot convert undefined or null to object". This migration failure cascaded into storage validation errors and eventually a white screen.

## Test plan
- [x] Built and linted successfully
- [x] All 250 unit tests passed
- [x] Playwright E2E tests: 26 passed, 1 known flaky failure (subscriptions.spec.ts)