### PR TITLE
fix-rollbar (6153/455144451390): Handle stale lens updates after workout finish

### DIFF
--- a/src/ducks/reducer.ts
+++ b/src/ducks/reducer.ts
@@ -618,7 +618,14 @@ export function buildCardsReducer(
         return newProgress;
       }
       case "UpdateProgress": {
-        return action.lensRecordings.reduce((memo, recording) => recording.fn(memo), progress);
+        try {
+          return action.lensRecordings.reduce((memo, recording) => recording.fn(memo), progress);
+        } catch (e) {
+          if (e instanceof Error && e.message.includes("LensError")) {
+            return progress;
+          }
+          throw e;
+        }
       }
     }
   };


### PR DESCRIPTION
## Summary
- Added try-catch wrapper around lens recording application in UpdateProgress reducer
- Gracefully handles LensError when lens path no longer exists after progress structure changes
- Prevents crash when onBlur events fire after FinishProgramDayAction modifies progress

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6153/occurrence/455144451390

## Decision
Fixed - this is a legitimate bug affecting normal user flows.

## Root Cause
Race condition between UI input blur events and workout finish action:
1. User modifies weight input (triggers onChange, creates lens recording)
2. User clicks "Finish workout" which runs FinishProgramDayAction
3. FinishProgramDayAction saves workout and removes entries from progress
4. Input's onBlur event fires with stale lens recording referencing removed entry
5. Lens library throws error when trying to access non-existent path (entries[5])

## Test plan
- [x] Build and TypeScript checks pass
- [x] Linting passes
- [x] Unit tests pass (250 tests)
- [x] Playwright E2E tests pass (28/33, failures are unrelated flaky subscription tests)