### PR TITLE
fix-rollbar (465/455235626400): Fix iOS Safari data URL fetch SyntaxError

### DIFF
--- a/src/utils/encoder.ts
+++ b/src/utils/encoder.ts
@@ -49,10 +49,13 @@ export function Encoder_decode(str: string): Promise<string> {
   return new Promise(async (resolve, reject) => {
     try {
       const dataUrl = atob(str);
-      const response = await fetch(dataUrl);
-      const blob = await response.blob();
-      const uintarray = await blob.arrayBuffer();
-      const result = await gunzipPromise(new Uint8Array(uintarray));
+      const base64Data = dataUrl.split(",")[1];
+      const binaryString = atob(base64Data);
+      const bytes = new Uint8Array(binaryString.length);
+      for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+      }
+      const result = await gunzipPromise(bytes);
       const textDecoder = new TextDecoder("utf-8");
       resolve(textDecoder.decode(result));
     } catch (e) {


### PR DESCRIPTION
## Summary
- Replace fetch() call with manual base64 decoding in Encoder_decode function
- Fixes SyntaxError: The string did not match the expected pattern on iOS Safari 15

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/465/occurrence/455235626400

## Decision
This error was worth fixing - it affects production iOS Safari 15 users when importing programs via shared links with encoded data.

## Root Cause
iOS Safari 15 has a bug where fetching long data URLs with fetch() fails with "SyntaxError: The string did not match the expected pattern." The error occurred when users clicked kebab menu in the program playground, which loads a compressed program via a data URL.

## Test plan
- [x] Build completes successfully
- [x] TypeScript type checking passes
- [x] All 250 unit tests pass
- [x] Manual verification: The fix decodes base64 data URLs without using fetch(), avoiding the Safari bug