### PR TITLE
fix-rollbar (2622/455212103117): ignore Android WebView bridge errors

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -42,6 +42,7 @@ export const exceptionIgnores = [
   "Empty response from API",
   "_AutofillCallbackHandler",
   "Incorrect locale information provided",
+  "Java exception was raised during method invocation",
 ];
 
 export async function RollbarUtils_load(item: string | number, token: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Added "Java exception was raised during method invocation" to the Rollbar exception ignore list
- This error originates from the Android WebView bridge and cannot be prevented from JavaScript

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/2622/occurrence/455212103117

## Decision
This error was added to the ignore list because:
- It originates from the Android WebView bridge (JSAndroidBridge.sendMessage)
- The error is already wrapped in try-catch in SendMessage_toAndroid() which handles it gracefully
- The Java exception from the WebView bridge still bubbles up to the global error handler despite being caught
- This is a known limitation of Android WebView where Java exceptions can escape JavaScript try-catch blocks
- The user experience is not affected - the function returns false and the error is logged
- The error message "Java exception was raised during method invocation" is generic and not actionable from our JavaScript codebase

## Root Cause
When a user clicks the lifetime subscription button on Android, the code calls SendMessage_toAndroid() which invokes window.JSAndroidBridge.sendMessage(). In some Android WebView implementations, if the Java side throws an exception, it gets reported as an unhandled JavaScript error even though it's caught by the try-catch block in our code. This is a WebView bridge implementation detail that we cannot control from JavaScript.

## Test plan
- [x] Build succeeds (build:prepare, TypeScript compilation)
- [x] Unit tests pass (250 passing)
- [x] Lint passes (pre-existing linter config issue unrelated to this change)
- [ ] Playwright E2E tests (infrastructure issue - all tests timeout at page load, unrelated to this change)