### PR TITLE
fix-rollbar (6158/455201336195): Fix infinite recursion in exercise page useEffect

### DIFF
--- a/src/pages/exercise/exerciseContent.tsx
+++ b/src/pages/exercise/exerciseContent.tsx
@@ -68,7 +68,7 @@ export function ExerciseContent(props: IExerciseContentProps): JSX.Element {
     if (c1) {
       c1.style.setProperty("height", `${maxHeight}px`);
     }
-  });
+  }, [exerciseType, filterTypes]);
 
   useEffect(() => {
     const onPopState = (e: PopStateEvent): void => {


### PR DESCRIPTION
## Summary
- Fixed infinite recursion bug in exercise page by adding proper dependency array to useEffect hook
- The hook was running on every render, modifying DOM properties which triggered re-renders

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6158/occurrence/455201336195

## Decision
This error was worth fixing because it caused a stack overflow affecting normal users viewing exercise pages in production.

## Root Cause
The `useEffect` hook at line 65 in `src/pages/exercise/exerciseContent.tsx` had no dependency array, causing it to run on every render. When the hook modified the DOM element's height style property, it triggered a layout recalculation which caused another render, creating an infinite loop. The alternating `il` and `gl` function calls in the stack trace were from Preact's rendering cycle getting stuck in this infinite recursion.

## Test plan
- [x] Unit tests pass
- [x] Build succeeds
- [x] Type checking passes
- [ ] Playwright E2E tests - all tests timed out, appears to be environmental issue unrelated to this change (affects app page, not exercise page)
