### PR TITLE
fix-rollbar (5861/455201335851): prevent infinite render loop in exercise page

### DIFF
--- a/src/pages/exercise/exerciseContent.tsx
+++ b/src/pages/exercise/exerciseContent.tsx
@@ -68,7 +68,7 @@ export function ExerciseContent(props: IExerciseContentProps): JSX.Element {
     if (c1) {
       c1.style.setProperty("height", `${maxHeight}px`);
     }
-  });
+  }, [exerciseType]);
 
   useEffect(() => {
     const onPopState = (e: PopStateEvent): void => {


### PR DESCRIPTION
## Summary
- Fixed useEffect hook with missing dependency array in exercise page
- Added exerciseType as dependency to prevent infinite render loops
- This prevents stack overflow errors when users view exercise pages

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/5861/occurrence/455201335851

## Decision
Fixed - this is a real bug causing stack overflow errors

## Root Cause
The useEffect hook on line 65-71 of exerciseContent.tsx had no dependency array, causing it to run after every render. When it set the height style property on the element, it triggered another render, creating an infinite loop that eventually caused a RangeError: Maximum call stack size exceeded.

## Test plan
- [x] Build succeeded  
- [x] Type checking passed
- [x] Unit tests passed (250 tests)
- [x] Linting completed (pre-existing eslint error in codemods/transform.ts, unrelated to this change)