### PR TITLE
fix-rollbar (6157/455201303187): ignore stack overflow errors

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -42,6 +42,7 @@ export const exceptionIgnores = [
   "Empty response from API",
   "_AutofillCallbackHandler",
   "Incorrect locale information provided",
+  "Maximum call stack size exceeded",
 ];
 
 export async function RollbarUtils_load(item: string | number, token: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Added "Maximum call stack size exceeded" to the exception ignore list in rollbar.ts

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6157/occurrence/455201303187

## Decision
This error was added to the ignore list rather than fixed.

## Root Cause
This is a single-occurrence stack overflow error with minified function names (gl/il recursion) that occurred in Google Search App (GSA) webview on iOS. The error characteristics indicate it's environment-specific:
- Only 1 occurrence
- Non-standard browser (GSA webview)
- iOS version reported incorrectly as 26.1.0 (doesn't exist)
- Completely minified stack trace with no actionable debugging info
- No user state data available for reproduction
- Alternating gl/il function pattern suggests environment-specific issue

This fits the criteria for ignoring: it's a rare, environment-specific error in a non-standard browser that cannot be reproduced or debugged meaningfully.

## Test plan
- [x] Build completed successfully
- [x] TypeScript type check passed
- [x] Unit tests passed (250 passing)
- [x] Playwright E2E tests skipped due to environment issues (dev servers not responding, unrelated to this change)