### PR TITLE
fix-rollbar (6165/455331347313): Ignore SyntaxError from unsupported old browsers

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -42,6 +42,7 @@ export const exceptionIgnores = [
   "Empty response from API",
   "_AutofillCallbackHandler",
   "Incorrect locale information provided",
+  "Unexpected token .",
 ];
 
 export async function RollbarUtils_load(item: string | number, token: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Added "Unexpected token ." to the Rollbar exception ignore list in `src/utils/rollbar.ts`

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6165/occurrence/455331347313

## Decision
Added to ignore list. The error is a `SyntaxError: Unexpected token .` from Chrome 75 on Android 9 ("Virtual Machine") — an ancient browser from 2019 that doesn't support optional chaining (`?.`). The script fails to parse at all (4ms runtime), there's no stack trace, no user state, and no exception data. This doesn't affect users on modern browsers.

## Root Cause
Modern JavaScript syntax (likely optional chaining `?.`) is not supported by Chrome 75 (released 2019). The browser cannot parse the bundled JavaScript, producing a generic `SyntaxError: Unexpected token .` before any app code executes.

## Test plan
- [x] Build succeeds
- [x] TypeScript type check passes
- [x] Unit tests pass (250 passing)
- [x] Playwright E2E tests pass (25 passed, 5 flaky with retries, 3 timeout failures unrelated to change)