### PR TITLE
fix-rollbar (6163/455325618248): Fix RangeError Invalid Date in Hevy CSV import

### DIFF
--- a/src/utils/importFromHevy.ts
+++ b/src/utils/importFromHevy.ts
@@ -364,14 +364,10 @@ export function ImportFromHevy_convertHevyCsvToHistoryRecords(
   const customExercises: Record<string, ICustomExercise> = {};
   const backMap: Partial<Record<string, string>> = {};
   const historyRecords: IHistoryRecord[] = hevyWorkouts.map((hevyWorkout) => {
-    let startTs: number | undefined;
-    try {
-      startTs = new Date(hevyWorkout.start_time).getTime();
-    } catch (_) {}
-    let endTs: number | undefined;
-    try {
-      endTs = new Date(hevyWorkout.end_time).getTime();
-    } catch (_) {}
+    const parsedStartTs = new Date(hevyWorkout.start_time).getTime();
+    const startTs = isNaN(parsedStartTs) ? undefined : parsedStartTs;
+    const parsedEndTs = new Date(hevyWorkout.end_time).getTime();
+    const endTs = isNaN(parsedEndTs) ? undefined : parsedEndTs;
     const entries = hevyWorkout.exercises.map((record, index) => {
       let exerciseNameAndEquipment = exerciseMapping[record.exercise_title];
       let exerciseId: string;

--- a/test/importFromHevy.test.ts
+++ b/test/importFromHevy.test.ts
@@ -1,0 +1,33 @@
+import "mocha";
+import { expect } from "chai";
+import { ImportFromHevy_convertHevyCsvToHistoryRecords } from "../src/utils/importFromHevy";
+import { Settings_build } from "../src/models/settings";
+
+describe("ImportFromHevy", () => {
+  describe("convertHevyCsvToHistoryRecords", () => {
+    it("handles invalid date strings without throwing", () => {
+      const csv = [
+        "title,start_time,end_time,exercise_title,description,exercise_notes,set_index,set_type,weight_lbs,weight_kg,reps",
+        "Workout,invalid-date,invalid-date,Squat (Barbell),,notes,0,normal,100,,5",
+      ].join("\n");
+      const settings = Settings_build();
+      const result = ImportFromHevy_convertHevyCsvToHistoryRecords(csv, settings);
+      expect(result.historyRecords).to.have.lengthOf(1);
+      expect(result.historyRecords[0].date).to.be.a("string");
+      expect(new Date(result.historyRecords[0].date).toString()).to.not.equal("Invalid Date");
+    });
+
+    it("parses valid dates correctly", () => {
+      const csv = [
+        "title,start_time,end_time,exercise_title,description,exercise_notes,set_index,set_type,weight_lbs,weight_kg,reps",
+        "Workout,2024-01-15T10:00:00Z,2024-01-15T11:00:00Z,Squat (Barbell),,notes,0,normal,100,,5",
+      ].join("\n");
+      const settings = Settings_build();
+      const result = ImportFromHevy_convertHevyCsvToHistoryRecords(csv, settings);
+      expect(result.historyRecords).to.have.lengthOf(1);
+      expect(result.historyRecords[0].date).to.equal("2024-01-15T11:00:00.000Z");
+      expect(result.historyRecords[0].startTime).to.equal(new Date("2024-01-15T10:00:00Z").getTime());
+      expect(result.historyRecords[0].endTime).to.equal(new Date("2024-01-15T11:00:00Z").getTime());
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fix `RangeError: Invalid Date` crash when importing Hevy CSV files with invalid date strings
- `new Date(invalidString).getTime()` returns `NaN` (not an exception), so the `try/catch` was ineffective and `NaN` passed through `??` operator since it's not `null`/`undefined`
- Replace try/catch with `isNaN()` check to properly detect and handle invalid dates

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6163/occurrence/455325618248

## Decision
Fixed — this is a real bug in a core user flow (Hevy CSV import) that crashes the app when the CSV contains malformed date values.

## Root Cause
`new Date(invalidString).getTime()` returns `NaN` instead of throwing an error. The code used `try/catch` to handle invalid dates, but since no exception is thrown, `endTs` was set to `NaN`. Then `NaN ?? Date.now()` evaluates to `NaN` (because `NaN` is not nullish), and `new Date(NaN).toISOString()` throws `RangeError: Invalid Date`.

## Test plan
- [x] Unit test added that reproduces the bug with invalid date strings
- [x] Unit test verifying valid dates still parse correctly
- [x] All 252 unit tests pass
- [x] Playwright E2E tests pass (2 failures are pre-existing flaky tests unrelated to this change)