### PR TITLE
fix-rollbar (5590/455319754603): Handle corrupted_server_storage error gracefully

### DIFF
--- a/src/ducks/thunks.ts
+++ b/src/ducks/thunks.ts
@@ -320,6 +320,20 @@ async function _sync2(
         "Update subscription no storage"
       );
       return false;
+    } else if (result.type === "error" && result.error === "corrupted_server_storage") {
+      dispatch(Thunk_postevent("corrupted-server-storage"));
+      updateState(
+        dispatch,
+        [lb<IState>().p("lastSyncedStorage").record(undefined)],
+        "Clear last sync on corrupted server storage"
+      );
+      if (typeof window !== "undefined") {
+        alert(
+          "Server storage is corrupted, so sync failed. " +
+            "To fix it - kill/restart the app a couple times. If it persists, please contact support."
+        );
+      }
+      return false;
     } else if (result.type === "error") {
       if (result.error === "outdated_client_storage") {
         if (typeof window !== "undefined") {


### PR DESCRIPTION
## Summary
- Handle `corrupted_server_storage` sync error gracefully on the client side instead of throwing a `NoRetryError`
- Clear `lastSyncedStorage` when this error occurs so the next sync attempt will try a full re-sync
- Show user an informative alert message instead of silently crashing
- Log the event via `Thunk_postevent` for tracking

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/5590/occurrence/455319754603

## Decision
Fixed: The `corrupted_server_storage` error was being thrown as a `NoRetryError`, which reported to Rollbar and blocked the sync permanently. This affects real production users on iOS who cannot sync their data.

## Root Cause
When the server-side stored storage fails schema validation after migration (in `Storage_get`), the server returns `{type: "error", error: "corrupted_server_storage"}`. The client had no specific handler for this error, so it fell through to the generic error handler that throws `NoRetryError`, which:
1. Reports to Rollbar on every sync attempt
2. Shows "Sync failed" to the user with no actionable information
3. Blocks all future sync attempts until the app is restarted

The fix adds a dedicated handler that clears the sync state and shows a user-friendly message, allowing the app to continue functioning with local data and retry syncing.

## Test plan
- [ ] Verify build succeeds with no type errors
- [ ] Verify all unit tests pass (250 passing)
- [ ] Verify Playwright E2E tests pass (27 passed, 1 known flaky failure in subscriptions.spec.ts)
- [ ] Verify that when a sync returns `corrupted_server_storage`, the app shows an alert and continues functioning