### PR TITLE
add-program: Candito 6-Week Strength

### DIFF
--- a/PROGRAMSTODO.md
+++ b/PROGRAMSTODO.md
@@ -10,7 +10,6 @@ Tactical Barbell Operator
 German Volume Training
 SBS Hypertrophy Program
 Creeping Death 2
-Candito 6-Week Strength
 Coolcicada PPL
 PHAT
 Candito Linear Program

--- a/programs/builtin/candito-6-week-strength.md
+++ b/programs/builtin/candito-6-week-strength.md
@@ -1,0 +1,331 @@
+---
+id: candito-6-week-strength
+name: "Candito 6-Week Strength"
+author: Jonnie Candito
+url: "https://canditotraininghq.com/"
+shortDescription: "A 6-week peaking program for squat, bench, and deadlift — ramps from 80% volume work to a 97.5% test in week 5, then deloads."
+isMultiweek: true
+tags: []
+frequency: 4
+age: "3_to_12_months"
+duration: "45-60"
+goal: "strength"
+---
+
+Jonnie Candito's 6-Week Strength Program is a powerlifting peaking program that cycles through muscular conditioning, hypertrophy, heavy acclimation, and intensity phases. It starts with higher-volume work at ~80% of 1RM across 4 training days per week and progressively reduces volume while increasing intensity, culminating in a single top set of 1-4 reps at 97.5% in week 5. Week 6 provides a deload to recover before repeating the cycle with updated maxes.
+
+<!-- more -->
+
+## Origin & Philosophy
+
+Jonnie Candito created this program as a formalization of his own training, which he used to become one of the strongest drug-tested USAPL junior lifters in the country and qualify for IPF Worlds. He released it for free on [CanditoTrainingHQ.com](https://canditotraininghq.com/) alongside an interactive spreadsheet that auto-calculates weights from your 1RM inputs.
+
+The core philosophy is periodization applied to an upper/lower split. Candito argues that periodization isn't just for advanced lifters — it's optimal for anyone because it prevents weaknesses before they develop. The program moves from moderate-intensity, higher-volume work (weeks 1-2) through heavy weight acclimation (weeks 3-4) to near-maximal testing (week 5), then resets. Each phase deliberately builds on the previous one: the early volume creates work capacity and muscle, the middle phase converts that into strength via heavier loads, and the final phase tests where you stand.
+
+## Who It's For
+
+- **Experience level**: Intermediate (1-3+ years of consistent barbell training). You need solid technique on [{Squat}], [{Bench Press}], and [{Deadlift}] because you'll be handling 90%+ loads by week 4.
+- **Prerequisites**: Known or estimated 1RMs for squat, bench, and deadlift. You should be comfortable squatting and deadlifting in the same session.
+- **Primary goal**: Strength — specifically peaking for new 1RMs on the big three lifts.
+- **Best suited for**: Meet preparation, breaking through plateaus on squat and deadlift, or any intermediate lifter who wants structured periodization. Works well on a bulk or at maintenance. Not ideal for cutting due to the high-intensity demands in weeks 4-5.
+
+## Pros & Cons
+
+**Pros**
+
+- Exceptional for [{Squat}] and [{Deadlift}] — many users report 5-10 lb PRs per cycle on squat, and even larger gains on deadlift
+- Intelligent fatigue management: volume tapers from ~56 squat reps in week 1 down to just 4 reps in week 5, letting accumulated fatigue dissipate while intensity rises
+- The week 5 test at 97.5% gives clear, measurable feedback — 2 reps means you're roughly at your old max, 4 reps means significant improvement
+- Free program with a well-designed spreadsheet, no guesswork required
+- Repeatable — designed to be run back-to-back with updated 1RMs after each cycle
+
+**Cons**
+
+- [{Bench Press}] programming is widely considered the weakest part — many experienced users replace it with Candito's Advanced Bench Program or another bench-specific routine
+- [{Squat}] and [{Deadlift}] are trained in the same session, which makes lower body days long and taxing, especially the week 2 AMRAP sessions
+- Limited accessory volume — optional exercises are deliberately kept light, which may not be enough for lifters who need direct arm, shoulder, or hamstring work
+- The week 2 paused back-off sets (5x3 with 60-second rest after an AMRAP) are brutally fatiguing and can cause technique breakdown if you're not disciplined about rest times
+
+## Program Structure
+
+- **Split**: Upper/lower. Lower days combine [{Squat}] and [{Deadlift}]. Upper days focus on [{Bench Press}] plus back, shoulder, and arm accessories.
+- **Periodization**: Linear periodization — volume decreases and intensity increases each week
+- **Training days per week**: 4 (2 upper, 2 lower) — weeks 1-2 use slightly higher frequency, but this implementation standardizes to 4 days for consistency
+- **Schedule**: Day 1 (Lower), Day 2 (Upper), Day 3 (Lower), Day 4 (Upper)
+
+## Exercise Selection & Rationale
+
+**Main lifts** — [{Squat}], [{Bench Press}], [{Deadlift}] — are the core of every session. Candito emphasizes compound movements over isolation work because they produce greater hormonal response and train movement patterns rather than individual muscles.
+
+**[{Deadlift}]** always appears on lower body days alongside [{Squat}], but at reduced volume (typically half the squat sets). This reflects Candito's approach of training both lifts with high intensity in the same session. A deadlift variation ([{Stiff Leg Deadlift}]) is used during the hypertrophy weeks to add posterior chain volume without the systemic fatigue of heavy conventional pulls.
+
+**Required accessories** on upper days target back, shoulders, and biceps: [{Bent Over Row}] for back thickness and deadlift carryover, [{Overhead Press}] for shoulder strength and bench lockout, [{Bicep Curl, Barbell}] for arm development and elbow health. Candito requires these on every upper body day because they directly support the main lifts.
+
+**Optional accessories** include [{Lateral Raise}] for shoulder width, [{Skullcrusher}] for tricep lockout strength, [{Leg Extension}] and [{Seated Leg Curl}] for quad and hamstring isolation. These are done only when you have energy remaining after the main work, at light weights for 8-12 reps.
+
+## Set & Rep Scheme
+
+**Weeks 1-2 (Muscular Conditioning / Hypertrophy)** — Moderate intensity, higher volume:
+- [{Squat}]: 4x6 at 80% (week 1), then AMRAP up to 10 reps at 80% followed by 5x3 paused back-off sets at 80% with 60-second rest (week 2)
+- [{Deadlift}]: 2x6 at 80% (week 1), then a deadlift variation 3x8 (week 2)
+- [{Bench Press}]: Descending pyramid — 1x10 at 50%, 1x10 at 67.5%, 1x8 at 75%, 1x6 at 77.5% (week 1), then AMRAP to 10 plus 5x3 paused back-offs (week 2)
+
+**Weeks 3-4 (Strength / Heavy Weight Acclimation)** — High intensity, low volume:
+- [{Squat}]: 3x4-6 at 85% (week 3), escalating triples at 87.5%/90%/92.5% (week 4)
+- [{Deadlift}]: 2x3-6 at 87.5% (week 3), 2x6 variation (week 4)
+- [{Bench Press}]: 3x4-6 at 85% (week 3), escalating triples at 86%/88%/90% (week 4)
+
+The week 2 AMRAP + paused back-off protocol is the program's signature: you work up to a max set of 10 reps, then immediately do 5 triples at the same weight with only 60 seconds rest between sets. This is designed to build work capacity and mental toughness under fatigue.
+
+**Week 5 (Intensity)** — Near-maximal test:
+- Each main lift gets a single top set of 1-4 reps at 97.5%. The number of reps you achieve predicts your new 1RM: 2 reps ≈ 96% (roughly your old max), 3 reps ≈ 93.5%, 4 reps ≈ 91% (significant improvement).
+
+**Week 6 (Deload)** — Recovery:
+- Main lifts at 60% for moderate sets and reps. No accessories. This allows full recovery before starting the next cycle.
+
+## Progressive Overload
+
+After each 6-week cycle, update your 1RMs based on your week 5 performance. Candito provides an estimation formula: multiply your week 5 weight by a factor based on reps completed (1 rep = 1.0, 2 reps = 1.04, 3 reps = 1.07, 4 reps = 1.09). Use the new estimated 1RM as input for the next cycle.
+
+**If you fail a set during the program**: Drop the 1RM on that lift by 5%. Don't repeat the workout — finish what you can and continue forward with the reduced max.
+
+**Deload**: Week 6 serves as the built-in deload at 60% of 1RM. If you choose to do actual 1RM testing in week 6 instead, add a 7th week as a deload before starting the next cycle.
+
+## How Long to Run It / What Next
+
+Run the program for **3-6 cycles** (18-36 weeks). Many users report consistent PRs on squat and deadlift cycle after cycle for 6+ months. Each cycle takes 6 weeks, so you can run 8-9 cycles per year.
+
+**Signs it's time to move on**: Your week 5 test numbers plateau across 2-3 consecutive cycles despite good recovery, or you find the bench press gains consistently lagging behind squat and deadlift.
+
+**What next**: If bench is the weak point, try Candito's Advanced Bench Press Program or a hybrid that combines the 6-week squat/deadlift work with dedicated bench programming. For more advanced periodization, consider [Bullmastiff](/programs/bullmastiff) or [GZCL: The Rippler](/programs/gzcl-the-rippler).
+
+## Equipment Needed
+
+- Barbell and plates
+- Squat rack
+- Flat bench
+- Pull-up bar (for optional back accessories)
+
+For the optional [{Leg Extension}] and [{Seated Leg Curl}], a gym with machines is needed. Free-weight substitutes: [{Bulgarian Split Squat}] for leg extensions, [{Stiff Leg Deadlift}] for leg curls.
+
+## Rest Times
+
+- **Main lifts (weeks 1-2)**: 3-5 minutes between sets. Exception: the week 2 paused back-off sets use 60-second rest.
+- **Main lifts (weeks 3-5)**: 3-8 minutes between sets. Heavier weights demand longer rest to maintain technique and output.
+- **Accessories**: 60-90 seconds between sets.
+
+## How to Pick Starting Weights
+
+The program is 100% percentage-based, so you only need to know your 1RM for [{Squat}], [{Bench Press}], and [{Deadlift}]. Set these as your 1RM values in the app.
+
+If you don't know your 1RM, use one of these methods:
+- **Rep max test**: Work up to a heavy set of 3-5 reps. Estimate 1RM using the formula: weight × (1 + reps/30). For example, 225 lbs × 5 reps = 225 × 1.167 = ~263 lbs estimated 1RM.
+- **Conservative start**: When in doubt, underestimate your 1RM by 5-10%. The first cycle will feel easy, but that's fine — it gives you room to learn the program's structure and set a baseline for future cycles.
+
+Common mistake: starting with an inflated 1RM. If your week 1 squats at 80% are grinding, your max is set too high.
+
+## Common Modifications
+
+- **Bench replacement**: The most popular modification is replacing the bench programming with Candito's Advanced 6-Week Bench Press Program. This is recommended if your bench consistently fails to improve on the standard program.
+- **Deadlift variation**: The program allows substituting the main deadlift with [{Sumo Deadlift}], [{Deficit Deadlift}], or [{Trap Bar Deadlift}]. Keep the same variation throughout the cycle.
+- **Accessory additions**: Many users add [{Face Pull}], [{Lateral Raise}], or direct tricep work on upper days. Keep these light (3x12-15) and don't let them interfere with main lift recovery.
+- **3-day variant**: If you can only train 3 days, combine upper/lower into full-body sessions. This is not ideal but works — prioritize the main lifts and cut accessories.
+
+<!-- faq -->
+
+### Is the Candito 6-Week Strength Program good for beginners?
+
+No. The program demands solid technique on Squat, Bench Press, and Deadlift at heavy loads (90%+ by week 4). Beginners will progress faster on a linear progression program that adds weight every session. Candito himself recommends his Linear Program for newer lifters.
+
+### How long does each workout take on the Candito 6-Week Program?
+
+Most sessions take 45-60 minutes. The exception is week 2 lower body days, which can run 75-90 minutes due to the AMRAP sets followed by paused back-off sets with strict 60-second rest periods.
+
+### Why does the Candito 6-Week Program not work well for bench press?
+
+The bench programming uses the same periodization structure as squat and deadlift, but bench responds better to higher frequency and volume than what this program provides. The early weeks use relatively high reps at moderate weight, which doesn't translate as well to bench 1RM improvements. Many users pair this program with a separate bench-specific routine.
+
+### Can I run the Candito 6-Week Strength Program on a cut?
+
+It's not recommended. The intensity demands in weeks 4-5 require good recovery, which is compromised in a caloric deficit. If you must run it while cutting, expect to reduce your 1RM inputs by 5-10% and accept that you may not PR on the week 5 test.
+
+### What should I do if I can't complete the prescribed sets in the Candito program?
+
+Drop your 1RM on that lift by 5% and continue the program. Don't repeat the failed workout. Candito specifically advises against going back — just adjust and move forward. If you're consistently failing sets across multiple lifts, your starting 1RMs were probably set too high.
+
+### How many times can I repeat the Candito 6-Week Program?
+
+Indefinitely, as long as you're still making progress. Many lifters run 4-8 cycles back-to-back (6-12 months) before needing to switch. Update your 1RMs after each cycle based on your week 5 test results.
+
+### Should I do the optional exercises in the Candito 6-Week Program?
+
+Only if you have energy left after the main work. Optional accessories should be light (8-12 reps) and should not interfere with recovery for the main lifts. If you're struggling to recover between sessions, cut the optional work first.
+
+### What is the week 5 test in the Candito 6-Week Program and how do I estimate my new max?
+
+In week 5, you perform a single top set of 1-4 reps at 97.5% of your current 1RM on each main lift. The number of reps you get estimates your new 1RM: multiply the weight by 1.04 (2 reps), 1.07 (3 reps), or 1.09 (4 reps). For example, if you do 4 reps at 390 lbs, your estimated new max is 390 x 1.09 = 425 lbs.
+
+```liftoscript
+# Week 1
+// Muscular Conditioning
+## Lower Body 1
+sq_mc / used: none / 4x6 / 80% / 180s / progress: custom(increment: 5lb) {~
+  if (completedReps >= reps && week == 5 && dayInWeek == 1) {
+    rm1 += state.increment
+  }
+~}
+dl_mc / used: none / 2x6 / 80% / 180s / progress: custom(increment: 5lb) {~
+  if (completedReps >= reps && week == 5 && dayInWeek == 1) {
+    rm1 += state.increment
+  }
+~}
+
+Squat / ...sq_mc
+Deadlift / ...dl_mc
+Leg Extension / 3x10 / 90s / warmup: none / progress: dp(5lb, 10, 15)
+Seated Leg Curl / 3x10 / 90s / warmup: none / progress: dp(5lb, 10, 15)
+
+## Upper Body 1
+bp_mc / used: none / 1x10 50%, 1x10 67.5%, 1x8 75%, 1x6 77.5% / 180s / progress: custom(increment: 5lb) {~
+  if (completedReps >= reps && week == 5 && dayInWeek == 2) {
+    rm1 += state.increment
+  }
+~}
+
+Bench Press / ...bp_mc
+Bent Over Row / 4x6 / 80% / 120s / progress: dp(5lb, 6, 10)
+Overhead Press / 3x8 / 120s / progress: dp(5lb, 8, 12)
+Bicep Curl, Barbell / 3x10 / 60s / warmup: none / progress: dp(5lb, 10, 15)
+
+## Lower Body 2
+sq_mc2 / used: none / 4x8 / 70% / 180s
+dl_mc2 / used: none / 2x8 / 70% / 180s
+
+Squat / ...sq_mc2
+Deadlift / ...dl_mc2
+Leg Extension / 3x10 / 90s / warmup: none
+Seated Leg Curl / 3x10 / 90s / warmup: none
+
+## Upper Body 2
+bp_mc2 / used: none / 4x6 / 80% / 180s
+
+Bench Press / ...bp_mc2
+Bent Over Row / 4x8 / 70% / 120s
+Overhead Press / 3x10 / 120s
+Bicep Curl, Barbell / 3x12 / 60s / warmup: none
+
+# Week 2
+// Hypertrophy
+## Lower Body 1
+sq_mc / 1x10+ / 80% / 180s
+dl_mc / 3x8 / 70%
+
+Leg Extension / 3x12 / 90s / warmup: none
+Seated Leg Curl / 3x12 / 90s / warmup: none
+
+## Upper Body 1
+bp_mc / 1x10+ / 80% / 180s
+
+Bent Over Row / 4x8 / 75% / 120s
+Overhead Press / 3x10 / 120s
+Bicep Curl, Barbell / 3x12 / 60s / warmup: none
+
+## Lower Body 2
+sq_mc2 / 1x10+ / 82.5%
+dl_mc2 / 3x8 / 72.5%
+
+Leg Extension / 3x12 / 90s / warmup: none
+Seated Leg Curl / 3x12 / 90s / warmup: none
+
+## Upper Body 2
+bp_mc2 / 1x10+ / 82.5%
+
+Bent Over Row / 4x8 / 77.5% / 120s
+Overhead Press / 3x10 / 120s
+Bicep Curl, Barbell / 3x12 / 60s / warmup: none
+
+# Week 3
+// Linear Max OT
+## Lower Body 1
+sq_mc / 3x5 / 85%
+dl_mc / 2x4 / 87.5%
+
+## Upper Body 1
+bp_mc / 3x5 / 85%
+
+Bent Over Row / 3x6 / 80% / 120s
+Overhead Press / 3x6 / 120s
+Bicep Curl, Barbell / 3x10 / 60s / warmup: none
+
+## Lower Body 2
+sq_mc2 / 3x5 / 85%
+dl_mc2 / 2x4 / 87.5%
+
+## Upper Body 2
+bp_mc2 / 3x5 / 85%
+
+Bent Over Row / 3x6 / 80% / 120s
+Overhead Press / 3x6 / 120s
+Bicep Curl, Barbell / 3x10 / 60s / warmup: none
+
+# Week 4
+// Heavy Weight Acclimation
+## Lower Body 1
+sq_mc / 1x3 87.5%, 1x3 90%, 1x3 92.5%
+dl_mc / 1x3 87.5%, 1x3 90%
+
+## Upper Body 1
+bp_mc / 1x3 86%, 1x3 88%, 1x3 90%
+
+Bent Over Row / 3x5 / 85% / 120s
+Overhead Press / 3x5 / 120s
+Bicep Curl, Barbell / 3x8 / 60s / warmup: none
+
+## Lower Body 2
+sq_mc2 / 1x2 90%, 1x2 92.5%, 1x2 95%
+dl_mc2 / 1x2 90%, 1x2 92.5%
+
+## Upper Body 2
+bp_mc2 / 1x2 88%, 1x2 90%, 1x2 92%
+
+Bent Over Row / 3x5 / 85% / 120s
+Overhead Press / 3x5 / 120s
+Bicep Curl, Barbell / 3x8 / 60s / warmup: none
+
+# Week 5
+// Intense Strength - Test
+## Squat Test
+sq_mc / 1x1-4+ / 97.5% / 300s
+dl_mc / 1x4 67.5%, 1x4 70%, 1x2 72.5%
+
+## Bench Test
+bp_mc / 1x1-4+ / 97.5% / 300s
+
+Bent Over Row / 3x5 / 80% / 120s
+
+## Deadlift Test
+dl_mc2 / 1x1-4+ / 97.5% / 300s
+sq_mc2 / 1x4 67.5%, 1x4 70%, 1x2 72.5%
+
+# Week 6
+// Deload
+## Lower Body 1
+sq_mc / 3x5 / 60% / 120s
+dl_mc / 2x5 / 60% / 120s
+
+## Upper Body 1
+bp_mc / 3x5 / 60% / 120s
+
+Bent Over Row / 3x8 / 60% / 90s
+Overhead Press / 3x8 / 90s
+
+## Lower Body 2
+sq_mc2 / 3x5 / 60%
+dl_mc2 / 2x5 / 60%
+
+## Upper Body 2
+bp_mc2 / 3x5 / 60%
+
+Bent Over Row / 3x8 / 60% / 90s
+Overhead Press / 3x8 / 90s
+```


### PR DESCRIPTION
## Summary
- Add built-in program: Candito 6-Week Strength

## Description
Jonnie Candito's 6-Week Strength Program is a powerlifting peaking program that cycles through muscular conditioning, hypertrophy, heavy weight acclimation, and intensity phases. It ramps from 80% volume work to a 97.5% test in week 5, then deloads. Designed for intermediate lifters looking to peak for new squat, bench, and deadlift PRs.

## Preview
https://www.liftosaur.com/program-preview?user=astashovai&commit=1f4a973cd7839593225c4297e3e28be21eee72ea&program=candito-6-week-strength

## Test plan
- [x] Liftoscript validates without errors
- [x] build:programs passes