### PR TITLE
add-program: Candito Linear Program

### DIFF
--- a/PROGRAMSTODO.md
+++ b/PROGRAMSTODO.md
@@ -13,7 +13,6 @@ Creeping Death 2
 Candito 6-Week Strength
 Coolcicada PPL
 PHAT
-Candito Linear Program
 TSA 9-Week Intermediate
 Westside for Skinny Bastards
 5/3/1 Triumvirate

--- a/programs/builtin/candito-linear-program.md
+++ b/programs/builtin/candito-linear-program.md
@@ -1,0 +1,199 @@
+---
+id: candito-linear-program
+name: "Candito Linear Program"
+author: Jonnie Candito
+url: "https://canditotraininghq.com/"
+shortDescription: "4-day upper/lower split with heavy days and paused control days for beginner to intermediate lifters"
+isMultiweek: false
+tags: []
+frequency: 4
+age: "less_than_3_months"
+duration: "60-90"
+goal: "strength"
+---
+
+Jonnie Candito's Linear Program is a 4-day upper/lower split built around [{Squat}], [{Bench Press}], and [{Deadlift}]. Two heavy days drive strength gains at 3x6 / 2x6 with weekly weight increases. Two control days use paused variations at 6x4 with lighter loads to build positional strength and reinforce technique. Simple linear progression: add weight each week, drop 15lb when you stall, and move to Candito's 6-Week Strength Program when resets stop working.
+
+<!-- more -->
+
+## Origin & Philosophy
+
+The Candito Linear Program was created by Jonnie Candito, an American powerlifter who once held the open American deadlift record at 650lb at 165lb bodyweight and medaled at the 2014 and 2015 IPF World Championships. Candito stated that he personally never uses a program outside of this linear program and his 6-Week Strength Program for his own training.
+
+The core philosophy is minimalism and focus. Rather than high-volume or complex periodization, the program keeps training simple: a handful of heavy compound sets with full effort, moderate accessory work, and a clear protocol for when to add weight and when to back off. The "control" days are the program's defining feature — using paused variations at reduced weight to strengthen weak points in the range of motion and build skill under tension.
+
+## Who It's For
+
+- **Experience level**: Beginner to early intermediate (0-18 months). Complete beginners should feel comfortable with barbell [{Squat}], [{Bench Press}], and [{Deadlift}] form before starting.
+- **Prerequisites**: Know your approximate 1RM or a comfortable working weight for the main lifts.
+- **Primary goal**: Strength, with secondary hypertrophy from accessory work.
+- **Diet**: Works on a bulk or maintenance. Can run on a cut, but expect slower progression and earlier stalls.
+
+## Pros & Cons
+
+**Pros**
+
+- Paused control days are a distinctive feature that builds positional strength and exposes form weaknesses early — most beginner programs skip this entirely
+- Only 2 working sets of [{Deadlift}] on heavy day keeps total fatigue manageable when paired with 3 sets of [{Squat}] in the same session
+- Heavy days finish in under 50 minutes — the low set counts (5 working sets for main lifts) and moderate accessory volume keep things efficient
+- Clear stall protocol: drop 15lb, reset up to 3 times, then slow to biweekly progression — no guesswork about when to change
+
+**Cons**
+
+- [{Squat}] and [{Deadlift}] on the same day can be challenging as weights get heavier — some lifters find the fatigue from heavy squats compromises their deadlift performance
+- Shoulder and vertical pull work is limited to 1 set of 6 on heavy upper day — this is deliberate (Candito wants focus on bench and rows) but may leave shoulders underdeveloped
+- No direct arm isolation in the base program — only the optional exercise slots provide opportunities for bicep and tricep work
+- The control day paused exercises require good body awareness and patience — beginners who rush through pauses will miss the benefit entirely
+
+## Program Structure
+
+- **Split**: Upper/lower, 4 days per week
+- **Periodization**: Straight linear progression — same sets and reps each week, only weight changes
+- **Fixed weekly schedule**: Heavy Lower → Heavy Upper → Rest → Control Lower → Control Upper → Rest → Rest
+- Heavy days use straight sets at working weight. Control days use paused variations at roughly 85-90% of heavy day weights.
+
+## Exercise Selection & Rationale
+
+**Heavy Lower**: [{Squat}] is the primary lower body driver. [{Deadlift}] follows with fewer sets (2 vs 3) because it shares the same session and is more fatiguing per set. Optional slots are for weak-point work — hamstring curls if your deadlift lockout is weak, leg press if your squat needs more quad volume.
+
+**Heavy Upper**: [{Bench Press}] is the primary push. [{Bent Over Row}] matches it 1:1 in sets for structural balance. [{Overhead Press}] and [{Lat Pulldown}] get a single heavy set each — Candito intentionally limits these to keep the session focused on bench and rows. Optional slots cover isolation: face pulls, lateral raises, curls, or tricep work.
+
+**Control Lower**: Paused [{Squat}] (pause at the bottom for 2-3 seconds) exposes and strengthens weak points in the hole. Paused [{Deadlift}] (pause just after the bar breaks the floor) strengthens the initial pull. Optional slots mirror heavy day.
+
+**Control Upper**: [{Bench Press}] with a pause just off the chest (Spoto press style) builds strength in the weakest part of the press and mimics competition bench technique. Paused [{Bent Over Row}] reinforces back engagement at the top of the pull. [{Overhead Press}] and [{Lat Pulldown}] increase to 1x10 for additional volume at lighter loads.
+
+The optional exercise slots can be filled with any isolation or machine work of your choice: [{Lateral Raise}], [{Face Pull}], [{Bicep Curl}], [{Skullcrusher}], [{Incline Chest Fly}], [{Preacher Curl}], or [{Hammer Curl}].
+
+## Set & Rep Scheme
+
+**Heavy days**: 3x6 for [{Squat}] and [{Bench Press}], 2x6 for [{Deadlift}], 3x6 for [{Bent Over Row}], 1x6 for [{Overhead Press}] and [{Lat Pulldown}]. The 6-rep range sits in the sweet spot between pure strength (1-5 reps) and hypertrophy (8-12 reps), allowing weekly progression while accumulating enough volume for muscle growth.
+
+**Control days**: 6x4 for paused [{Squat}] and [{Bench Press}], 3x4 for paused [{Deadlift}], 6x4 for paused [{Bent Over Row}]. The lower reps (4) account for the longer time under tension from the pause, and the higher set count (6) maintains sufficient total volume. [{Overhead Press}] and [{Lat Pulldown}] shift to 1x10 to accumulate volume at lighter weight.
+
+**Optional exercises**: 3x8-12 on all days — standard hypertrophy range for accessory work.
+
+## Progressive Overload
+
+**When to add weight**: After completing all prescribed sets and reps at a given weight, add 5lb to upper body lifts ([{Bench Press}], [{Overhead Press}], [{Bent Over Row}], [{Lat Pulldown}]) and 10lb to lower body lifts ([{Squat}], [{Deadlift}]) the following week.
+
+**Control day weights**: These track the heavy day weights automatically. When heavy day weight goes up, control day weight follows proportionally (roughly 85-90% of heavy day weight).
+
+**When you stall**: If you fail to complete all sets and reps at a given weight, drop that lift's weight by 15lb the next week and build back up. This only applies to the lift you failed — keep other lifts progressing normally.
+
+**After 3 resets**: If you've had to drop weight 3 times on the same lift, switch to biweekly progression (add weight every 2 weeks instead of every week). This will take most beginners several months to reach.
+
+**When biweekly progression stalls**: After 3 failures on biweekly progression, Candito recommends transitioning to his 6-Week Strength Program, which uses periodized blocks to push past plateaus. You can alternate between the two programs.
+
+**Optional exercises**: Progress every 3 weeks by adding 0-10lb, not every week. These are low-priority; don't let chasing accessory PRs affect recovery for the main lifts.
+
+## How Long to Run It / What Next
+
+Run the Candito Linear Program as long as you're still making weekly (or biweekly) progress on the main lifts. For most beginners, this means 3-6 months. Intermediates coming from another program may get 2-4 months before needing periodization.
+
+**Signs it's time to move on**: You've reset a lift 3+ times on biweekly progression, your sessions are getting excessively long due to rest times, or you're consistently failing the same weights.
+
+**What next**: Candito's own recommendation is his 6-Week Strength Program, which uses 6-week periodized cycles with varying rep ranges. Other good options include [5/3/1 for Beginners](/programs/the531-for-beginners) for a structured periodized approach, or [GZCLP](/programs/gzclp) if you want to stay on linear progression a bit longer with a tier-based structure.
+
+## Equipment Needed
+
+- Barbell and plates (the only absolute requirement)
+- Power rack or squat rack (for squats and bench press safety)
+- Pull-up bar or lat pulldown machine
+- Optional: dumbbells for accessories, cable machine for face pulls and curls
+
+All exercises can be done with a basic barbell, rack, and bench setup. For [{Lat Pulldown}], substitute [{Chin Up}] or banded [{Pull Up}] if no machine is available.
+
+## Rest Times
+
+- **Heavy day main lifts** ([{Squat}], [{Bench Press}], [{Deadlift}], [{Bent Over Row}]): 3-5 minutes between sets. Candito emphasizes taking full rest — rushing these kills your ability to set PRs.
+- **Control day paused lifts**: 2-3 minutes between sets. The lighter weight doesn't demand as much recovery.
+- **Single sets** ([{Overhead Press}], [{Lat Pulldown}]): No specific rest — just transition to the next exercise.
+- **Optional exercises**: 60-90 seconds. These are for pump and volume, not maximal effort.
+
+## How to Pick Starting Weights
+
+**Heavy days**: Start at roughly 75-80% of your 1RM. For example, if your [{Bench Press}] max is 225lb, start around 170-180lb for 3x6. The weight should be challenging but you should have no chance of failure on week 1 — you need room to progress.
+
+**Control days**: Start at roughly 70% of your 1RM (or about 85-90% of your heavy day weight). The pause makes each rep significantly harder, so the weight drop is necessary.
+
+**If you don't know your 1RM**: Start conservatively. Do a session where you work up to a weight that feels like an RPE 7-8 for 6 reps (2-3 reps left in the tank), and use that as your starting weight. It's always better to start too light than too heavy — you'll catch up within 2-3 weeks.
+
+**Optional exercises**: Start light and focus on feeling the muscle work. These aren't about heavy weights.
+
+## Common Modifications
+
+- **Swap [{Bent Over Row}] for [{Bent Over Row, Dumbbell}]**: Acceptable, but barbell rows allow heavier loading and more precise linear progression.
+- **Replace [{Lat Pulldown}] with [{Chin Up}] or [{Pull Up}]**: Common and effective. Use bodyweight or add weight with a belt as you progress.
+- **Add a 5th day for arms/shoulders**: Candito doesn't prescribe this, but many lifters find their arms lag behind. A short 20-30 minute session of curls, tricep extensions, and lateral raises won't hurt recovery.
+- **3-day variant**: Keep both heavy days and alternate the control day each week. Week 1: Heavy Lower, Heavy Upper, Control Lower. Week 2: Heavy Lower, Heavy Upper, Control Upper. Repeat.
+- **Switch to the Hypertrophy variant**: Replace control days with higher-volume work. Lower hypertrophy day: [{Squat}] or [{Front Squat}] 5x8, deadlift variation 3x8, [{Seated Leg Curl}] 3x12, [{Standing Calf Raise}] 5x15. Upper hypertrophy day: [{Bench Press, Dumbbell}] 4x8, [{Incline Bench Press, Dumbbell}] 4x8, upper back 4x8, shoulder press 3x8.
+- **Switch to the Power variant**: Replace control lower day with explosive work — box jumps, jump squats, or power cleans done in sets of 4 reps. The control upper day stays the same since there aren't many effective explosive upper body movements with consistent progressive overload.
+
+<!-- faq -->
+
+### Is the Candito Linear Program good for beginners?
+
+Yes, it's designed for beginner to early intermediate lifters. The Strength/Control variant is specifically recommended for beginners because the paused lifts teach good positioning and build body awareness. You should know basic Squat, Bench Press, and Deadlift form before starting.
+
+### How many days per week is the Candito Linear Program?
+
+The standard program is 4 days per week: Heavy Lower on Monday, Heavy Upper on Tuesday, Control Lower on Thursday, and Control Upper on Friday. There's also a 3-day variant where you alternate the control days week to week.
+
+### What's the difference between the Control, Power, and Hypertrophy variants?
+
+All three share the same heavy days (Monday and Tuesday). The Control variant uses paused lifts on the lighter days to build technique. The Power variant replaces the control lower day with explosive movements like box jumps and power cleans. The Hypertrophy variant replaces both control days with higher-volume work at 8-12 reps. Candito recommends the Control variant for most people.
+
+### How much weight should I add each week on the Candito Linear Program?
+
+Add 5lb per week to upper body lifts (Bench Press, Overhead Press, Bent Over Row) and 10lb per week to lower body lifts (Squat, Deadlift). For optional exercises, add weight every 3 weeks instead.
+
+### What should I do when I stall on the Candito Linear Program?
+
+Drop the weight by 15lb on the lift you failed and build back up. Only reset the lift you stalled on — keep other lifts progressing normally. After 3 resets on the same lift, switch to biweekly progression (adding weight every 2 weeks). After 3 more failures, transition to Candito's 6-Week Strength Program.
+
+### How long should I run the Candito Linear Program?
+
+Run it as long as you're making progress — typically 3-6 months for beginners. There's no set end date. Once you've exhausted biweekly progression on multiple lifts, it's time to move to a periodized program like Candito's 6-Week Strength Program or 5/3/1.
+
+### Can I replace the paused lifts on control days with regular lifts?
+
+You can, but you'll lose the main benefit of the Control variant. The pauses build positional strength and expose form weaknesses that regular reps don't. If you don't want paused work, consider the Hypertrophy variant instead, which uses higher-rep straight sets on the lighter days.
+
+### Should I do warm-up sets before the working sets?
+
+Yes. Candito's program assumes you warm up before working sets. For main lifts, do 2-3 progressively heavier warm-up sets leading up to your working weight — for example, empty bar x 10, 50% x 5, 75% x 3 before your working sets. The app handles warm-up sets automatically.
+
+```liftoscript
+# Week 1
+## Heavy Lower
+Squat / 3x6 / 135lb / progress: lp(10lb, 1, 0, 15lb, 1, 0)
+Deadlift / 2x6 / 185lb / progress: lp(10lb, 1, 0, 15lb, 1, 0)
+Seated Leg Curl / 3x10 / 60lb / progress: dp(5lb, 8, 12)
+Standing Calf Raise / 3x10 / 35lb / progress: dp(5lb, 8, 12)
+
+## Heavy Upper
+Bench Press / 3x6 / 135lb / progress: lp(5lb, 1, 0, 15lb, 1, 0)
+Bent Over Row / 3x6 / 95lb / progress: lp(5lb, 1, 0, 15lb, 1, 0)
+Overhead Press / 1x6 / 75lb / progress: lp(5lb, 3, 0, 15lb, 1, 0)
+Lat Pulldown / 1x6 / 70lb / progress: lp(5lb, 3, 0, 15lb, 1, 0)
+Face Pull / 3x12 / progress: dp(5lb, 10, 15)
+Lateral Raise / 3x12 / 15lb / progress: dp(5lb, 10, 15)
+
+## Control Lower
+// Pause **2-3 seconds** at the bottom of each rep.
+control: Squat / 6x4 / 115lb / 120s / progress: lp(10lb, 1, 0, 15lb, 1, 0)
+// Pause **2-3 seconds** just after the bar breaks the floor.
+control: Deadlift / 3x4 / 155lb / 120s / progress: lp(10lb, 1, 0, 15lb, 1, 0)
+Seated Leg Curl / 3x10 / 60lb
+Standing Calf Raise / 3x10 / 35lb
+
+## Control Upper
+// Pause **2-3 seconds** with the bar ~1 inch off the chest (Spoto press style).
+control: Bench Press / 6x4 / 115lb / 120s / progress: lp(5lb, 1, 0, 15lb, 1, 0)
+// Pause **2-3 seconds** at the top of the row (bar touching torso).
+control: Bent Over Row / 6x4 / 80lb / 120s / progress: lp(5lb, 1, 0, 15lb, 1, 0)
+Overhead Press / 1x10 / 55lb
+Lat Pulldown / 1x10 / 55lb
+Face Pull / 3x12
+Lateral Raise / 3x12 / 15lb
+```


### PR DESCRIPTION
## Summary
- Add built-in program: Candito Linear Program

## Description
Jonnie Candito's 4-day upper/lower split for beginner to intermediate lifters. Features heavy strength days (3x6/2x6) and unique paused control days (6x4) to build positional strength and technique. Implements the Strength/Control variant with linear progression, stall protocol (drop 15lb), and accessories.

## Preview
https://www.liftosaur.com/program-preview?user=astashovai&commit=${COMMIT_HASH}&program=candito-linear-program

## Test plan
- [x] Liftoscript validates without errors
- [x] build:programs passes