### PR TITLE
fix-rollbar (6187/455449578585): add null check for PopStateEvent.state in rep max calculator

### DIFF
--- a/src/pages/repmax/repMaxContent.tsx
+++ b/src/pages/repmax/repMaxContent.tsx
@@ -25,7 +25,7 @@ export function RepMaxContent(props: IRepMaxContentProps): JSX.Element {
 
   useEffect(() => {
     const onPopState = (e: PopStateEvent): void => {
-      if (e.state.reps) {
+      if (e.state?.reps) {
         setReps(e.state.reps);
       }
     };


### PR DESCRIPTION
## Summary
- Add optional chaining (`e.state?.reps`) to the `popstate` event handler in the rep max calculator page to prevent crash when `PopStateEvent.state` is null

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6187/occurrence/455449578585

## Decision
Fixed because this is a real bug in our code affecting a normal user flow on the `/five-rep-max-calculator` page. When users navigate via browser back/forward buttons to a history entry that was never given state (e.g., the initial page load entry), `PopStateEvent.state` is `null`, causing a TypeError crash.

## Root Cause
The `popstate` event handler in `src/pages/repmax/repMaxContent.tsx` accessed `e.state.reps` without checking if `e.state` is null. The browser's `PopStateEvent.state` property is `null` for history entries that were not created via `pushState()` or `replaceState()`. When a user navigates to `/five-rep-max-calculator` and then uses back/forward navigation before the `setTimeout` in `useEffect` has a chance to call `replaceState`, the handler crashes.

## Test plan
- [ ] Navigate to `/five-rep-max-calculator`
- [ ] Use browser back button - should not crash
- [ ] Use browser forward button - should not crash
- [ ] Select different rep values and verify URL updates and back/forward navigation works correctly