### PR TITLE
fix-rollbar (4783/455442653838): null check e.state in repmax popstate handler

### DIFF
--- a/src/pages/repmax/repMaxContent.tsx
+++ b/src/pages/repmax/repMaxContent.tsx
@@ -25,7 +25,7 @@ export function RepMaxContent(props: IRepMaxContentProps): JSX.Element {
 
   useEffect(() => {
     const onPopState = (e: PopStateEvent): void => {
-      if (e.state.reps) {
+      if (e.state?.reps) {
         setReps(e.state.reps);
       }
     };


### PR DESCRIPTION
## Summary
- Add optional chaining (`e.state?.reps`) in the `popstate` event handler in `RepMaxContent` to prevent TypeError when `e.state` is null

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/4783/occurrence/455442653838

## Decision
Fixed because this is a real bug in our code affecting the rep max calculator page for normal users. `PopStateEvent.state` can be `null` when navigating back to a history entry that wasn't created via `pushState`/`replaceState` (e.g., the initial page load entry).

## Root Cause
The `popstate` event handler in `repMaxContent.tsx` accesses `e.state.reps` without first checking if `e.state` is null. The browser's `PopStateEvent.state` property is `null` for history entries that don't have an associated state object (such as the initial page load). When a user navigates back to such an entry, the handler crashes with `TypeError: null is not an object (evaluating 'e.state.reps')`.

## Test plan
- [ ] Navigate to the rep max calculator page
- [ ] Use browser back/forward navigation to trigger popstate events
- [ ] Verify no TypeError occurs when navigating to entries without state