### PR TITLE
add-program: Arnold Split

### DIFF
--- a/PROGRAMSTODO.md
+++ b/PROGRAMSTODO.md
@@ -1,4 +1,3 @@
-Arnold Split |-| 17920 - 4/5
 German Volume Training |-| 3540 - 3/5
 Westside Conjugate Method |-| 1900 - 1/5
 Shortcut to Size (Jim Stoppani) |-| 1600 - 2/5

--- a/programs/builtin/arnold-split-17920-4-5.md
+++ b/programs/builtin/arnold-split-17920-4-5.md
@@ -1,0 +1,224 @@
+---
+id: arnold-split-17920-4-5
+name: "Arnold Split"
+author: Arnold Schwarzenegger
+url: "https://www.muscleandstrength.com/workouts/arnold-schwarzenegger-volume-workout-routines"
+shortDescription: "Arnold Schwarzenegger's classic 6-day bodybuilding split — chest/back, shoulders/arms, legs, each trained twice per week"
+isMultiweek: false
+tags: []
+frequency: 6
+age: "more_than_year"
+duration: "60-90"
+goal: "hypertrophy"
+---
+
+A 6-day high-volume bodybuilding split made famous by Arnold Schwarzenegger during his competitive career. Each workout pairs antagonist muscle groups — chest with back, shoulders with arms — and every muscle group is trained twice per week. Based on the Basic Training Program from Arnold's *The New Encyclopedia of Modern Bodybuilding*, adapted for practical use with double progression.
+
+<!-- more -->
+
+## Origin & Philosophy
+
+The Arnold Split comes from Arnold Schwarzenegger's *The New Encyclopedia of Modern Bodybuilding* (1985, revised 1998), where he laid out a series of training programs ranging from basic to advanced. The "Basic Training Program #1" is the foundation that most people refer to as the Arnold Split. Arnold used variations of this 6-day structure throughout his competitive career, winning seven Mr. Olympia titles between 1970 and 1980.
+
+The core principle is **antagonist pairing**: training opposing muscle groups in the same session. Chest pushes, back pulls. Biceps flex, triceps extend. This allows one muscle group to rest while the other works, improving workout density and creating a natural superset structure. Arnold believed this approach produced a better pump and allowed more total work in less time compared to training synergist muscles together (like chest with triceps).
+
+Arnold also advocated training each muscle group **twice per week** with high volume per session — typically 3-4 exercises per muscle group with 4 sets each. He used a pyramid approach (lighter weight/higher reps building to heavier weight/lower reps) and trained to or near muscular failure on working sets.
+
+## Who It's For
+
+- **Experience level**: Intermediate to advanced (1+ years of consistent training). You need the work capacity to handle 20+ working sets per session across two muscle groups, six days per week.
+- **Prerequisites**: Proficiency in all major compound lifts (bench press, row, overhead press, squat, deadlift). You should already be comfortable training 4-5 days per week before jumping to 6.
+- **Primary goal**: Hypertrophy. The high volume, twice-weekly frequency, and exercise variety from multiple angles make this a pure muscle-building program.
+- **Best suited for**: Bulking or maintenance phases. The training volume is too high to recover from properly on a caloric deficit — on a cut, drop to a 4-day upper/lower or PPL instead.
+
+## Pros & Cons
+
+**Pros**
+
+- Every muscle group trained twice per week, hitting the frequency sweet spot that [research supports](https://pubmed.ncbi.nlm.nih.gov/27102172/) for hypertrophy
+- Antagonist pairing (chest/back, biceps/triceps) allows one muscle to recover while the other works, improving session efficiency
+- High per-session volume (12-16 sets per muscle group) creates strong metabolic stress and pump
+- Chest and back paired together means you can superset presses and rows to cut session time
+- Broad exercise selection hits muscles from multiple angles — 3 chest exercises cover flat, incline, and fly patterns
+- 48-hour minimum rest between sessions for the same muscle group (Day 1 chest → Day 4 chest)
+
+**Cons**
+
+- Requires 6 training days per week — missing sessions disrupts the rotation and extends recovery gaps
+- Shoulders and triceps get indirect work on chest/back day, then direct work the next day — this overlap can cause fatigue accumulation in the front delts and triceps
+- High total weekly volume (80+ working sets) demands strong recovery: 7-8 hours of sleep, adequate calories, and managed life stress
+- Sessions run 60-75 minutes with compound-heavy days (chest/back, legs) potentially reaching 90 minutes
+- No built-in deload — you need to self-manage fatigue by taking a deload week every 4-6 weeks
+- Not suitable for cutting or calorie-restricted phases due to the recovery demands
+
+## Program Structure
+
+- **Split**: Antagonist pairing — Chest & Back / Shoulders & Arms / Legs, repeated twice per week
+- **Periodization**: Double progression (add reps within range, then add weight) on all exercises
+- **Schedule**: Fixed 6-day rotation — Day 1-3 then repeat Day 4-6 with Day 7 off
+- **Typical week**: Chest+Back → Shoulders+Arms → Legs → Chest+Back → Shoulders+Arms → Legs → Rest
+
+The same workouts are repeated on days 4-6 as on days 1-3. This means you train each muscle group with the same exercises twice per week. Arnold's original version used identical sessions; this implementation follows that approach with a single set of workouts repeated.
+
+## Exercise Selection & Rationale
+
+**Chest & Back** pairs horizontal pressing with horizontal and vertical pulling. [{Bench Press}] is the primary chest mass builder. [{Incline Bench Press, Dumbbell}] shifts emphasis to the upper chest and adds unilateral balance. [{Chest Fly}] isolates the pecs through a full stretch. On the back side, [{Chin Up}] is a vertical pull for lat width and bicep involvement. [{Bent Over Row}] builds mid-back thickness. [{Deadlift}] is included as a full posterior chain builder — Arnold considered it essential for overall back development. These exercises can be supersetted in antagonist pairs (bench/chin-up, incline/row, fly/deadlift) to cut session time.
+
+**Shoulders & Arms** combines all three delt heads with bicep and tricep work. [{Overhead Press}] is the primary compound press for anterior and lateral delts. [{Lateral Raise}] directly targets the lateral head, which pressing alone doesn't develop sufficiently. [{Reverse Fly}] covers the rear delts, balancing out the pressing volume in this program. For arms, [{Bicep Curl, Barbell}] and [{Hammer Curl}] hit the biceps from two grip angles (supinated and neutral), while [{Skullcrusher}] and [{Triceps Pushdown}] target the triceps long head (under stretch) and lateral head (peak contraction) respectively. Arnold was famous for his arm development and always included direct arm work.
+
+**Legs** starts with [{Squat}] as the primary quad and glute builder. [{Lunge}] adds single-leg work for balance and glute emphasis. [{Lying Leg Curl}] isolates the hamstrings. [{Stiff Leg Deadlift}] works the hamstrings and glutes through a hip hinge, complementing the quad-dominant squat. [{Standing Calf Raise}] targets the gastrocnemius — Arnold trained calves with high volume, often doing 15-20+ reps per set. [{Crunch}] is added for direct core work, which Arnold included in most sessions.
+
+**Substitution options**: [{Bench Press}] can be swapped for [{Bench Press, Dumbbell}]. [{Chin Up}] can be replaced with [{Lat Pulldown}] if you can't do enough reps. [{Deadlift}] can be swapped for [{T Bar Row}] if deadlift fatigue is too high. [{Overhead Press}] can be replaced with [{Arnold Press}]. [{Lunge}] can be swapped for [{Bulgarian Split Squat}] or [{Leg Press}].
+
+## Set & Rep Scheme
+
+- **Heavy compounds** ([{Bench Press}], [{Bent Over Row}], [{Overhead Press}], [{Squat}], [{Deadlift}]): 4 sets in the 8-12 rep range. Arnold typically used 4 sets per exercise and trained in the 8-12 rep range for most movements.
+- **Secondary compounds** ([{Incline Bench Press, Dumbbell}], [{Chin Up}], [{Lunge}], [{Stiff Leg Deadlift}]): 3-4 sets in the 8-12 rep range.
+- **Isolation exercises** ([{Chest Fly}], [{Lateral Raise}], [{Reverse Fly}], [{Lying Leg Curl}], [{Bicep Curl, Barbell}], [{Skullcrusher}]): 3-4 sets in the 10-15 rep range with controlled form.
+- **Calves and abs**: 4-5 sets in the 15-25 rep range. Arnold advocated higher reps for these muscle groups.
+
+Arnold's guiding rule was: "I make a point of never doing less than 6 repetitions per set with most movements, and nothing higher than 12." This implementation widens the rep ranges slightly on isolation work (up to 15) to accommodate the double progression model and ensure adequate metabolic stress.
+
+## Progressive Overload
+
+All exercises use **double progression**: work within the prescribed rep range, and when you can hit the top-end reps on all sets, add weight and reset to the bottom of the range.
+
+- **Barbell compounds** ([{Bench Press}], [{Bent Over Row}], [{Overhead Press}], [{Squat}], [{Deadlift}], [{Stiff Leg Deadlift}]): Add **5lb** per successful progression (10lb for deadlift and squat).
+- **Dumbbell and isolation exercises**: Add **5lb** per successful progression.
+
+For example, [{Bench Press}] starts at 4x8. Each session you try to add reps: 4x8 → 4x9 → ... → 4x12. Once you hit 4x12, weight goes up by 5lb and you reset to 4x8.
+
+**When you stall**: If you can't add reps for 2-3 consecutive sessions, reduce the weight by 10-15% and build back up. The built-in rep range acts as an auto-regulating mechanism.
+
+**Deloads**: Take a deload week every 4-6 weeks — cut volume in half (reduce sets from 4 to 2, or reduce weight by 40-50%) for one week, then resume normal training.
+
+## How Long to Run It / What Next
+
+Run the Arnold Split for **8-16 weeks** before reassessing. Most lifters find the high volume productive for at least 2-3 months. Take a deload week every 4-6 weeks.
+
+**Signs it's time to move on**: Persistent fatigue despite deloads, joint pain (especially shoulders from the overlap between chest/back and shoulder/arm days), or stalling on most exercises.
+
+**Transition to**: [PHUL](/programs/phul) for a 4-day upper/lower split if you want to reduce training days while maintaining frequency. [Metallicadpa PPL](/programs/metallicadpappl) for a 6-day PPL that separates pushing and pulling instead of pairing antagonists. [5/3/1: Boring But Big](/programs/the531bbb) if you want to shift toward strength with structured periodization.
+
+## Equipment Needed
+
+- **Barbell and plates** — for bench press, bent over row, overhead press, squat, deadlift, stiff leg deadlift, barbell curl, skullcrusher
+- **Dumbbells** — for incline press, chest fly, lateral raise, reverse fly, hammer curl
+- **Pull-up bar** — for chin-ups
+- **Cable machine** — for triceps pushdown (can substitute with dumbbell triceps extension)
+- **Leg curl machine** — for lying leg curl (can substitute with Nordic hamstring curl or additional RDL sets)
+
+**Home gym substitutions**:
+- [{Chin Up}] → [{Lat Pulldown}] or [{Inverted Row}]
+- [{Triceps Pushdown}] → [{Triceps Extension}] (overhead dumbbell)
+- [{Lying Leg Curl}] → additional [{Stiff Leg Deadlift}] sets or [{Glute Bridge}]
+
+## Rest Times
+
+- **Heavy compounds** ([{Bench Press}], [{Bent Over Row}], [{Overhead Press}], [{Squat}], [{Deadlift}]): **2-3 minutes** between sets. If supersetting antagonist pairs (bench/chin-up, row/incline press), rest 60-90 seconds between exercises within the superset, then 2 minutes before the next superset.
+- **Secondary compounds and isolation**: **60-90 seconds** between sets
+- **Calves and abs**: **60 seconds** or less
+
+## How to Pick Starting Weights
+
+**If you know your 1RM**: Use approximately 65-70% for compound exercises (8-12 rep range) and 50-60% for isolation exercises (10-15 rep range).
+
+**If you don't know your 1RM**: Start with a weight where you can complete all prescribed sets with 2-3 reps in reserve on the first session. The double progression will ramp you up within 2-3 weeks.
+
+**Common mistake**: Starting too heavy. Arnold's approach was high volume — you're doing 20+ working sets per session. If you start at your true 8RM for every exercise, you'll be crushed by the third exercise. Leave room to progress.
+
+## Common Modifications
+
+- **Add supersets**: Pair chest and back exercises as antagonist supersets (e.g., [{Bench Press}] into [{Chin Up}], [{Incline Bench Press, Dumbbell}] into [{Bent Over Row}]). This is how Arnold actually trained and can cut chest/back day from 75 minutes to 50 minutes.
+- **Add rear delts on chest/back day**: If [{Reverse Fly}] once on shoulder day isn't enough, add [{Face Pull}] (3x15) at the end of chest/back day.
+- **Swap deadlift placement**: Move [{Deadlift}] from chest/back day to leg day and add [{Seated Row}] or [{Lat Pulldown}] in its place if deadlift fatigue is hurting your row performance.
+- **Add more ab work**: Arnold trained abs almost daily. Add [{Hanging Leg Raise}] or [{Cable Crunch}] to chest/back day and leg day for additional core volume.
+- **5-day variant**: If 6 days is too demanding, run the split as Day 1/2/3, rest, Day 4/5, rest — dropping one leg day. This gives 4 upper body sessions and 1 leg session per week.
+- **Reduce arm volume**: If your arms are growing well from compound work alone, drop one bicep and one tricep exercise from shoulder/arm day to shorten the session.
+
+<!-- faq -->
+
+### Is the Arnold Split good for beginners?
+
+No. The Arnold Split demands 6 training days per week with 20+ working sets per session. Beginners make better progress with less volume and fewer training days — a 3-day full-body program or a basic upper/lower split provides faster strength gains and more recovery time while you build work capacity.
+
+### How many days a week is the Arnold Split?
+
+The Arnold Split is a 6-day program with one rest day. You train chest and back on days 1 and 4, shoulders and arms on days 2 and 5, and legs on days 3 and 6. Day 7 is a full rest day. Missing a day disrupts the rotation, so consistency is important.
+
+### What makes the Arnold Split different from PPL?
+
+The Arnold Split pairs antagonist muscles (chest with back, biceps with triceps), while PPL groups synergist muscles (chest with shoulders and triceps on push day, back with biceps on pull day). The Arnold Split enables antagonist supersets for time efficiency, but creates more overlap between consecutive days since chest/back day fatigues triceps and front delts before shoulder/arm day.
+
+### How long should I run the Arnold Split?
+
+Run it for 8-16 weeks. Take a deload week every 4-6 weeks by cutting volume in half. If you're still progressing after 16 weeks, you can continue — just monitor joint health, especially in the shoulders, and take deloads consistently.
+
+### Can I do the Arnold Split on a cut?
+
+It's not recommended. The program's high volume (80+ working sets per week across 6 days) demands significant recovery resources. On a caloric deficit, your recovery is impaired. A 4-day upper/lower split or 3-day full body routine is more appropriate for cutting phases.
+
+### Should I superset exercises on the Arnold Split?
+
+Supersetting antagonist pairs is how Arnold actually trained and is one of the program's strengths. On chest and back day, pair Bench Press with Chin Ups and Incline Press with Rows. This maintains intensity while cutting session time significantly. Rest 60-90 seconds between exercises within a superset, then 2 minutes before the next round.
+
+### What if I can't train 6 days a week?
+
+If you can only train 5 days, drop one leg session and run the split as chest/back, shoulders/arms, legs, chest/back, shoulders/arms. If you can only train 4 days, consider switching to a different program like PHUL or an upper/lower split — the Arnold Split's value comes from its 6-day frequency.
+
+### How do I handle the shoulder overlap between chest/back day and shoulder/arm day?
+
+This is the most common complaint about the Arnold Split. Your front delts and triceps work hard on chest/back day (pressing movements), then get trained directly the next day. To manage this: keep chest/back day pressing volume moderate, prioritize lateral and rear delt work on shoulder/arm day over additional pressing, and monitor for shoulder pain. If your front delts are always sore going into shoulder day, reduce bench press volume by one set.
+
+```liftoscript
+# Week 1
+## Chest & Back
+Bench Press / 4x8 / 135lb / 120s / progress: dp(5lb, 8, 12)
+Incline Bench Press, Dumbbell / 3x8 / 30lb / 90s / progress: dp(5lb, 8, 12)
+Chest Fly / 3x10 / 20lb / 60s / progress: dp(5lb, 10, 15)
+Chin Up / 4x8 / 0lb / 120s / warmup: none / progress: dp(5lb, 8, 12)
+Bent Over Row / 4x8 / 95lb / 120s / progress: dp(5lb, 8, 12)
+Deadlift / 3x8 / 225lb / 120s / progress: dp(10lb, 8, 12)
+
+## Shoulders & Arms
+Overhead Press / 4x8 / 85lb / 120s / progress: dp(5lb, 8, 12)
+Lateral Raise / 4x10 / 15lb / 60s / progress: dp(5lb, 10, 15)
+Reverse Fly / 3x10 / 15lb / 60s / progress: dp(5lb, 10, 15)
+Bicep Curl, Barbell / 4x8 / 55lb / 60s / progress: dp(5lb, 8, 12)
+Hammer Curl / 3x10 / 25lb / 60s / progress: dp(5lb, 10, 12)
+Skullcrusher / 4x8 / 40lb / 60s / progress: dp(5lb, 8, 12)
+Triceps Pushdown / 3x10 / 40lb / 60s / progress: dp(5lb, 10, 12)
+
+## Legs
+Squat / 4x8 / 185lb / 120s / progress: dp(10lb, 8, 12)
+Lunge / 3x10 / 65lb / 90s / progress: dp(5lb, 10, 12)
+Lying Leg Curl / 4x10 / 60lb / 60s / progress: dp(5lb, 10, 15)
+Stiff Leg Deadlift / 3x8 / 135lb / 90s / progress: dp(5lb, 8, 12)
+Standing Calf Raise / 5x15 / 100lb / 60s / progress: dp(5lb, 15, 20)
+Crunch / 4x20 / 0lb / 60s / warmup: none
+
+## Chest & Back 2
+Bench Press / 4x8 / 135lb / 120s
+Incline Bench Press, Dumbbell / 3x8 / 30lb / 90s
+Chest Fly / 3x10 / 20lb / 60s
+Chin Up / 4x8 / 0lb / 120s / warmup: none
+Bent Over Row / 4x8 / 95lb / 120s
+Deadlift / 3x8 / 225lb / 120s
+
+## Shoulders & Arms 2
+Overhead Press / 4x8 / 85lb / 120s
+Lateral Raise / 4x10 / 15lb / 60s
+Reverse Fly / 3x10 / 15lb / 60s
+Bicep Curl, Barbell / 4x8 / 55lb / 60s
+Hammer Curl / 3x10 / 25lb / 60s
+Skullcrusher / 4x8 / 40lb / 60s
+Triceps Pushdown / 3x10 / 40lb / 60s
+
+## Legs 2
+Squat / 4x8 / 185lb / 120s
+Lunge / 3x10 / 65lb / 90s
+Lying Leg Curl / 4x10 / 60lb / 60s
+Stiff Leg Deadlift / 3x8 / 135lb / 90s
+Standing Calf Raise / 5x15 / 100lb / 60s
+Crunch / 4x20 / 0lb / 60s / warmup: none
+```


### PR DESCRIPTION
## Summary
- Add built-in program: Arnold Split

## Description
Arnold Schwarzenegger's classic 6-day bodybuilding split from *The New Encyclopedia of Modern Bodybuilding*. Pairs antagonist muscle groups (chest/back, shoulders/arms) with each trained twice per week. Uses double progression for all exercises. Designed for intermediate to advanced lifters focused on hypertrophy.

## Preview
https://www.liftosaur.com/program-preview?user=astashovai&commit=3ec087055e8b948bd7bafcf2cfc329273a9ea785&program=arnold-split-17920-4-5

## Test plan
- [x] Liftoscript validates without errors
- [x] build:programs passes