### PR TITLE
add-program: Shortcut to Size (Jim Stoppani) |-| 1600 - 2/5

### DIFF
--- a/PROGRAMSTODO.md
+++ b/PROGRAMSTODO.md
@@ -1,7 +1,6 @@
 Arnold Split |-| 17920 - 4/5
 German Volume Training |-| 3540 - 3/5
 Westside Conjugate Method |-| 1900 - 1/5
-Shortcut to Size (Jim Stoppani) |-| 1600 - 2/5
 PHAT |-| 1210 - 1/5
 Juggernaut Method 2.0 |-| 1770 - 3/5
 Calgary Barbell 16-Week |-| 1050 - 1/5

--- a/programs/builtin/shortcut-to-size-jim-stoppani-1600-2-5.md
+++ b/programs/builtin/shortcut-to-size-jim-stoppani-1600-2-5.md
@@ -1,0 +1,290 @@
+---
+id: shortcut-to-size-jim-stoppani-1600-2-5
+name: "Shortcut to Size (Jim Stoppani)"
+author: Jim Stoppani
+url: "https://www.jimstoppani.com/training/shortcut-to-size-introduction/"
+shortDescription: "A 12-week linear periodization bodybuilding program cycling through 4 weekly rep ranges across 3 phases, with exercise variation each phase."
+isMultiweek: true
+tags: []
+frequency: 4
+age: "3_to_12_months"
+duration: "90+"
+goal: "hypertrophy"
+---
+
+Jim Stoppani's Shortcut to Size is a 12-week bodybuilding program built on linear periodization. Each 4-week phase cycles through four rep ranges — 12-15, 9-11, 6-8, and 3-5 — progressively increasing weight and decreasing reps week to week. Exercises rotate between phases to hit muscles from different angles while primary compound lifts stay consistent for trackable strength gains. The 4-day body-part split trains chest/triceps, back/biceps, shoulders/traps, and legs each once per week.
+
+<!-- more -->
+
+## Origin & Philosophy
+
+Shortcut to Size was created by [Jim Stoppani, Ph.D.](https://www.jimstoppani.com/training/shortcut-to-size-introduction/), an exercise physiologist who served as senior science editor at Muscle & Fitness magazine. Originally published on Bodybuilding.com, the program distills Stoppani's research into a structured 12-week hypertrophy plan.
+
+The core principle is **linear periodization within microcycles** — each week uses a different rep range, progressing from high reps/light weight (week 1: 12-15 reps) to low reps/heavy weight (week 4: 3-5 reps). After completing one 4-week phase, you reset to high reps but at heavier weights than the previous phase. This cycling exposes muscles to different training stimuli — metabolic stress in higher-rep weeks and mechanical tension in lower-rep weeks — while preventing adaptation plateaus.
+
+## Who It's For
+
+- **Experience level**: Beginner to intermediate (3+ months of consistent gym training). You should know basic barbell and dumbbell form but don't need advanced technique.
+- **Primary goal**: Hypertrophy with secondary strength gains.
+- **Best suited for**: Bulking or maintenance phases. The volume and intensity demand adequate caloric intake — running this on an aggressive cut will impair recovery.
+
+## Pros & Cons
+
+**Pros**
+
+- Weekly rep range cycling (12-15 → 9-11 → 6-8 → 3-5) prevents adaptation and provides both hypertrophy and strength stimuli
+- Exercise variation across phases targets muscles from different angles — e.g., [{Incline Bench Press}] in Phase 1 swaps to [{Incline Bench Press, Dumbbell}] in Phase 2
+- High volume per muscle group (10-13 working sets for large groups, 9-10 for small groups per session) drives hypertrophy
+- Clear structure makes it easy to follow — same exercises within a phase, just change the weight/rep range each week
+- Calves and abs are trained twice per week, which smaller muscles respond well to
+
+**Cons**
+
+- Each muscle group is only trained once per week, which may be suboptimal for hypertrophy compared to twice-per-week frequency
+- Chest/triceps and back/biceps sessions run 75-90 minutes due to the high exercise count (9-10 exercises)
+- The 3-5 rep range in week 4 applied to isolation exercises like [{Cable Crossover}] and [{Lateral Raise}] is questionable — heavy isolation work increases injury risk with minimal benefit
+- No programmed deload — after 12 weeks of escalating intensity, you may accumulate significant fatigue
+- Rest-pause and drop set techniques on the last set of every exercise (as prescribed in the original program) are not implemented here, since they require real-time autoregulation that a tracking app cannot manage
+
+## Program Structure
+
+- **Split**: 4-day body-part split — Chest/Triceps/Calves, Back/Biceps/Abs, Shoulders/Traps/Calves, Legs/Abs
+- **Periodization**: Linear periodization with weekly microcycles (12-15 → 9-11 → 6-8 → 3-5 reps) repeated over three 4-week phases
+- **Schedule**: Fixed weekly — typically Mon/Tue/Thu/Fri with Wed and weekends as rest days
+- **Exercise rotation**: Primary compound movements ([{Bench Press}], [{Squat}], [{Shoulder Press, Dumbbell}], [{Bent Over Row, Dumbbell}]) stay constant across all 12 weeks. Assistance exercises change each phase to provide novel stimulus
+
+## Exercise Selection & Rationale
+
+**Chest/Triceps/Calves (Day 1)**: [{Bench Press}] is the primary chest builder across all phases. Assistance pressing rotates between barbell incline (Phase 1), dumbbell incline (Phase 2), and reverse-grip dumbbell incline (Phase 3) to vary the angle and grip. Fly movements shift between incline dumbbell flyes, flat flyes, and cable work across phases. Triceps follow a push-down → extension → overhead pattern, rotating cable and dumbbell variations. Calves get high-volume work (8 sets) to compensate for their once-per-week frequency on this day.
+
+**Back/Biceps/Abs (Day 2)**: [{Bent Over Row, Dumbbell}] anchors the session. Pulldown variations rotate between wide-grip, behind-neck, and reverse-grip across phases. Cable rows and straight-arm pulldowns provide different pull angles. Biceps follow a similar rotation pattern — barbell curls stay constant while incline curls, preacher curls, concentration curls, and cable curls rotate through phases. Abs are trained with hip flexion, spinal flexion, and rotational movements.
+
+**Shoulders/Traps/Calves (Day 3)**: [{Shoulder Press, Dumbbell}] is the primary overhead press across all phases. Lateral, front, and rear delt work rotates between dumbbell and cable variations. Trap work alternates between dumbbell and barbell shrugs. A second calf session provides the twice-per-week frequency.
+
+**Legs/Abs (Day 4)**: [{Squat}] is the primary quad builder. Secondary quad work rotates between single-leg leg press (Phase 1), [{Front Squat}] (Phase 2), and [{Leg Press}] (Phase 3), always followed by [{Leg Extension}]. [{Romanian Deadlift, Barbell}] anchors the posterior chain, with lying or seated leg curls as assistance. A second ab session rounds out the week.
+
+## Set & Rep Scheme
+
+- **Week 1 of each phase**: 12-15 reps — lighter weight, higher metabolic stress, emphasizes time under tension
+- **Week 2 of each phase**: 9-11 reps — moderate weight, balanced stimulus
+- **Week 3 of each phase**: 6-8 reps — heavier weight, increased mechanical tension
+- **Week 4 of each phase**: 3-5 reps — near-maximal weight, primarily strength-focused
+- **Primary exercises**: 4 sets. **Assistance exercises**: 3 sets.
+- **Calves**: 4 sets per exercise, with higher rep ranges (25-30 in week 1, down to 6-9 in week 4) due to the high endurance capacity of calf muscles
+- **Abs**: 3 sets per exercise, with rep ranges from 20-30 (week 1) down to 6-9 (week 4)
+
+## Progressive Overload
+
+Progression happens at two levels:
+
+1. **Within each phase (weekly)**: Weight increases each week as reps decrease. Week 1 uses a weight you can handle for 12-15 reps; by week 4 you should be near your 3-5 rep max for each exercise.
+2. **Between phases**: When the rep range resets to 12-15 at the start of Phase 2 and Phase 3, you use 5-20lb more than the same rep range in the previous phase. Over 12 weeks, this compounds to 10-40lb increases on major lifts.
+
+This implementation uses **double progression** — increase reps within the prescribed range, and when you hit the top of the range on all sets, add weight (5lb for upper body, 10lb for lower body compounds) and reset to the bottom of the range. The weight increment happens automatically when all reps are completed.
+
+There is no built-in deload. If you stall, reduce weight by 10% and work back up.
+
+## How Long to Run It / What Next
+
+Run the full 12 weeks as written. After completing all three phases, take a deload week (50% volume at 60% intensity), then consider:
+
+- Running it again with the heavier weights you've built up to
+- Transitioning to a higher-frequency program like [PHUL](/programs/phul) to capitalize on your new strength base with twice-per-week muscle group frequency
+- Moving to a strength-focused program like [5/3/1: Boring But Big](/programs/the531bbb) if you want to push your compound lifts further
+
+Signs it's time to move on: you can no longer add weight between phases, recovery is consistently poor, or you want higher training frequency.
+
+## Equipment Needed
+
+- Barbell and plates
+- Dumbbells
+- Cable machine (for crossovers, pushdowns, curls, lateral raises)
+- Squat rack
+- Flat and incline bench
+- Leg press and leg extension/curl machines
+- Calf raise machines (standing and seated)
+
+**Free-weight substitutions for cable exercises:**
+
+- [{Cable Crossover}] → [{Chest Fly}] or [{Chest Fly, Dumbbell}]
+- [{Triceps Pushdown}] → [{Skullcrusher}] or close-grip push-ups
+- [{Lateral Raise, Cable}] → [{Lateral Raise}] (dumbbell)
+- [{Seated Row}] → [{Bent Over Row}] (barbell)
+
+## Rest Times
+
+- **Compound exercises** ([{Bench Press}], [{Squat}], [{Shoulder Press, Dumbbell}], [{Romanian Deadlift, Barbell}]): 2-3 minutes
+- **Isolation exercises** ([{Chest Fly}], [{Lateral Raise}], [{Bicep Curl, Barbell}]): 60-90 seconds
+- **Calves and abs**: 60 seconds
+
+## How to Pick Starting Weights
+
+For each exercise, select a weight you can complete for 12-15 reps with 1-2 reps left in reserve. This is your Week 1 weight. Each subsequent week, increase the weight enough to stay within the prescribed rep range (9-11, 6-8, then 3-5). A rough guide: Week 2 weight is ~10% heavier than Week 1, Week 3 is ~20% heavier, and Week 4 is ~30% heavier.
+
+If you know your 1RM, Week 1 weights should be approximately 60-65% of 1RM, and Week 4 weights should approach 85-90% of 1RM.
+
+**Common mistake**: starting too heavy in Week 1. The 12-15 rep range should feel moderate — you need headroom to increase weight for 3 more weeks.
+
+## Common Modifications
+
+- **Skip the 3-5 rep week for isolation exercises**: Keep isolation movements at 6-8 reps in Week 4 and only drop to 3-5 on compound lifts. This reduces injury risk on movements like flyes and lateral raises.
+- **Add a 5th day for arms**: If arm growth is a priority, add a dedicated arm day with 3-4 bicep and 3-4 tricep exercises.
+- **Swap to 3-day version**: Combine shoulders with chest/triceps and train Mon/Wed/Fri.
+- **Add rear delt work to back day**: [{Face Pull}] or [{Reverse Fly}] at the end of the back session for shoulder health.
+- **Replace behind-neck pulldown**: [{Lat Pulldown}] with a wide or neutral grip is safer for most lifters.
+
+<!-- faq -->
+
+### Is Shortcut to Size good for beginners?
+
+Shortcut to Size works for beginners who have at least 3 months of gym experience and understand basic exercise form. The program's structured progression and clear rep ranges make it easy to follow. Complete beginners should first build a base with a simpler full-body program for 2-3 months before starting.
+
+### How long does a Shortcut to Size workout take?
+
+Chest/Triceps and Back/Biceps days typically run 75-90 minutes due to the high number of exercises (9-10 per session). Shoulders and Legs days are shorter at 45-60 minutes. Using shorter rest periods (60-90 seconds) can reduce session time by 15-20 minutes.
+
+### Can I run Shortcut to Size on a cut?
+
+You can, but expect slower progression and potentially higher fatigue. The program's volume is designed for a caloric surplus. On a cut, consider reducing total sets by 1 per exercise (e.g., 3 sets instead of 4 on primary movements) and prioritizing sleep and protein intake (at least 1g per pound of bodyweight).
+
+### Why do the exercises change between phases in Shortcut to Size?
+
+Exercise rotation every 4 weeks provides novel muscle stimulus from different angles, which helps prevent adaptation plateaus. For example, switching from Incline Barbell Press in Phase 1 to Incline Dumbbell Press in Phase 2 changes the stabilization demands and range of motion while still targeting the upper chest.
+
+### What should I do if I stall on Shortcut to Size?
+
+If you can't increase weight between phases, reduce your working weights by 10% and rebuild. Most stalls come from inadequate recovery — check that you're sleeping 7-9 hours, eating enough protein (1-1.5g per pound of bodyweight), and managing stress. The 3-5 rep week is where most people stall first.
+
+### Is once per week per muscle group enough for hypertrophy?
+
+Research suggests twice-per-week frequency may be slightly superior for hypertrophy, but once-per-week training with sufficient volume (10+ sets per muscle group) still produces significant growth. Shortcut to Size compensates with high per-session volume. If you want higher frequency, consider adding a light pump session for lagging body parts on rest days.
+
+### Can I substitute exercises in Shortcut to Size?
+
+Yes — keep the primary compound movements (Bench Press, Squat, Dumbbell Shoulder Press, Dumbbell Row) consistent for progression tracking, but feel free to swap assistance exercises for similar movement patterns. For example, replace Lying Leg Curl with Seated Leg Curl, or Cable Crossover with Dumbbell Flyes.
+
+```liftoscript
+# Week 1
+## Chest, Triceps, Calves
+main4[1-12] / used: none / 4x12 / 4x9 / 4x6 / 4x3 / progress: custom(increment: 5lb) {~
+  setVariationIndex = (setVariationIndex % 4) + 1
+  if (setVariationIndex == 1) {
+    weights += state.increment
+  }
+~}
+aux3[1-12] / used: none / 3x12 / 3x9 / 3x6 / 3x3 / progress: custom(increment: 5lb) { ...main4 }
+sm3[1-12] / used: none / 3x12 / 3x9 / 3x6 / 3x3 / progress: custom(increment: 2.5lb) { ...main4 }
+calf4[1-12] / used: none / 4x25 / 4x15 / 4x10 / 4x6 / progress: custom(increment: 5lb) { ...main4 }
+
+Bench Press[1-4] / ...main4 / 135lb
+Incline Bench Press[1-4] / ...aux3 / 115lb
+Incline Chest Fly[1-4] / ...aux3 / 30lb / warmup: none
+Cable Crossover[1-4] / ...aux3 / 30lb / warmup: none
+Triceps Pushdown[1-4] / ...aux3 / 40lb / warmup: none
+Skullcrusher[1-4] / ...aux3 / 55lb / warmup: none
+Triceps Extension, Cable[1-4] / ...aux3 / 30lb / warmup: none
+Standing Calf Raise[1-12] / ...calf4 / 90lb / warmup: none
+Seated Calf Raise[1-12] / ...calf4 / 50lb / warmup: none
+
+## Back, Biceps, Abs
+Bent Over Row, Dumbbell[1-4] / ...main4 / 30lb
+Lat Pulldown[1-4] / ...aux3 / 80lb / warmup: none
+Kneeling Pulldown[1-4] / ...aux3 / 60lb / warmup: none
+Straight Leg Deadlift[1-4] / ...aux3 / 65lb / warmup: none
+Bicep Curl, Barbell[1-4] / ...main4 / 45lb / warmup: none
+Incline Curl[1-4] / ...sm3 / 15lb / warmup: none
+Bicep Curl, Cable[1-4] / ...aux3 / 20lb / warmup: none
+Hip Thrust[1-12] / 3x20 / 95lb / warmup: none / progress: none
+Crunch[1-12] / 3x20 / 0lb / warmup: none / progress: none
+Oblique Crunch[1-4] / 3x20 / 0lb / warmup: none / progress: none
+
+## Shoulders, Traps, Calves
+Shoulder Press, Dumbbell[1-4] / ...main4 / 25lb
+Lateral Raise[1-4] / ...sm3 / 15lb / warmup: none
+Front Raise, Cable[1-4] / ...sm3 / 10lb / warmup: none
+Reverse Fly[1-4] / ...sm3 / 15lb / warmup: none
+Shrug[1-4] / ...main4 / 45lb / warmup: none
+Seated Calf Raise[1-12] / ...calf4 / 50lb / warmup: none
+Calf Press on Leg Press[1-12] / ...calf4 / 180lb / warmup: none
+
+## Legs, Abs
+low4[1-12] / used: none / 4x12 / 4x9 / 4x6 / 4x3 / progress: custom(increment: 10lb) { ...main4 }
+low3[1-12] / used: none / 3x12 / 3x9 / 3x6 / 3x3 / progress: custom(increment: 5lb) { ...main4 }
+
+Squat[1-4] / ...low4 / 135lb
+Leg Press[1-4] / ...low3 / 180lb / warmup: none
+Leg Extension[1-4] / ...low3 / 60lb / warmup: none
+Romanian Deadlift, Barbell[1-4] / ...low4 / 135lb
+Lying Leg Curl[1-4] / ...low3 / 60lb / warmup: none
+Hip Thrust[1-12] / 3x20 / 95lb / warmup: none / progress: none
+Crunch[1-12] / 3x20 / 0lb / warmup: none / progress: none
+Plank[1-12] / 3x30 / 0lb / warmup: none / progress: none
+
+# Week 5
+## Chest, Triceps, Calves
+Bench Press[5-8] / ...main4 / 135lb
+Incline Bench Press, Dumbbell[5-8] / ...aux3 / 40lb
+Chest Fly[5-8] / ...aux3 / 30lb / warmup: none
+Incline Chest Fly, Cable[5-8] / ...aux3 / 15lb / warmup: none
+Triceps Pushdown[5-8] / ...aux3 / 40lb / warmup: none
+Triceps Extension[5-8] / ...aux3 / 20lb / warmup: none
+Skullcrusher, Cable[5-8] / ...aux3 / 40lb / warmup: none
+
+## Back, Biceps, Abs
+Bent Over Row, Dumbbell[5-8] / ...main4 / 30lb
+Behind The Neck Press[5-8] / ...aux3 / 45lb / warmup: none
+Seated Row[5-8] / ...aux3 / 65lb / warmup: none
+Lat Pulldown[5-8] / ...aux3 / 80lb / warmup: none
+Bicep Curl, Barbell[5-8] / ...main4 / 45lb / warmup: none
+Preacher Curl[5-8] / ...aux3 / 15lb / warmup: none
+Bicep Curl, Cable[5-8] / ...aux3 / 20lb / warmup: none
+Oblique Crunch[5-8] / 3x20 / 0lb / warmup: none / progress: none
+
+## Shoulders, Traps, Calves
+Shoulder Press, Dumbbell[5-8] / ...main4 / 25lb
+Upright Row, Barbell[5-8] / ...aux3 / 45lb / warmup: none
+Lateral Raise, Cable[5-8] / ...sm3 / 10lb / warmup: none
+Reverse Fly[5-8] / ...sm3 / 15lb / warmup: none
+Shrug, Barbell[5-8] / ...main4 / 135lb / warmup: none
+
+## Legs, Abs
+Squat[5-8] / ...low4 / 135lb
+Front Squat[5-8] / ...low3 / 95lb
+Leg Extension[5-8] / ...low3 / 60lb / warmup: none
+Romanian Deadlift, Barbell[5-8] / ...low4 / 135lb
+Seated Leg Curl[5-8] / ...low3 / 60lb / warmup: none
+
+# Week 9
+## Chest, Triceps, Calves
+Bench Press[9-12] / ...main4 / 135lb
+Incline Bench Press, Dumbbell[9-12] / ...aux3 / 40lb
+Incline Chest Fly[9-12] / ...aux3 / 30lb / warmup: none
+Cable Crossover[9-12] / ...aux3 / 30lb / warmup: none
+Triceps Pushdown[9-12] / ...aux3 / 40lb / warmup: none
+Triceps Extension, Cable[9-12] / ...aux3 / 30lb / warmup: none
+Bench Press Close Grip[9-12] / ...aux3 / 95lb
+
+## Back, Biceps, Abs
+Bent Over Row, Dumbbell[9-12] / ...main4 / 30lb
+Lat Pulldown[9-12] / ...aux3 / 80lb / warmup: none
+Kneeling Pulldown[9-12] / ...aux3 / 60lb / warmup: none
+Seated Row[9-12] / ...aux3 / 65lb / warmup: none
+Bicep Curl, Barbell[9-12] / ...main4 / 45lb / warmup: none
+Incline Curl[9-12] / ...sm3 / 15lb / warmup: none
+Concentration Curl[9-12] / ...sm3 / 15lb / warmup: none
+Oblique Crunch[9-12] / 3x20 / 0lb / warmup: none / progress: none
+
+## Shoulders, Traps, Calves
+Shoulder Press, Dumbbell[9-12] / ...main4 / 25lb
+Lateral Raise[9-12] / ...sm3 / 15lb / warmup: none
+Upright Row[9-12] / ...aux3 / 25lb / warmup: none
+Reverse Fly[9-12] / ...sm3 / 15lb / warmup: none
+Shrug[9-12] / ...main4 / 45lb / warmup: none
+
+## Legs, Abs
+Squat[9-12] / ...low4 / 135lb
+Leg Press[9-12] / ...low3 / 180lb / warmup: none
+Leg Extension[9-12] / ...low3 / 60lb / warmup: none
+Romanian Deadlift, Barbell[9-12] / ...low4 / 135lb
+Lying Leg Curl[9-12] / ...low3 / 60lb / warmup: none
+```


### PR DESCRIPTION
## Summary
- Add built-in program: Shortcut to Size (Jim Stoppani) |-| 1600 - 2/5

## Description
Jim Stoppani's 12-week linear periodization bodybuilding program using a 4-day body-part split. Each 4-week phase cycles through 4 rep ranges (12-15 → 9-11 → 6-8 → 3-5), with exercise variations rotating between phases. Suited for beginner to intermediate lifters focused on hypertrophy.

## Preview
https://www.liftosaur.com/program-preview?user=astashovai&commit=c53d8bbbd104f27abfb7dca77cdccc25e6d31714&program=shortcut-to-size-jim-stoppani-1600-2-5

## Test plan
- [x] Liftoscript validates without errors
- [x] build:programs passes