### PR TITLE
fix-rollbar (6203/455505292588): exclude auto-generated dp script from progress equality check

### DIFF
--- a/src/pages/planner/plannerExerciseEvaluator.ts
+++ b/src/pages/planner/plannerExerciseEvaluator.ts
@@ -161,12 +161,16 @@ export class PlannerExerciseEvaluator {
   }
 
   public static isEqualProgress(a: IProgramExerciseProgress, b: IProgramExerciseProgress): boolean {
+    const fields: (keyof IProgramExerciseProgress)[] =
+      a.type === "dp" && b.type === "dp"
+        ? ["type", "state", "stateMetadata"]
+        : ["type", "state", "stateMetadata", "script"];
     const pickA = {
-      ...ObjectUtils_pick(a, ["type", "state", "stateMetadata", "script"]),
+      ...ObjectUtils_pick(a, fields),
       reuse: a.reuse?.fullName,
     };
     const pickB = {
-      ...ObjectUtils_pick(b, ["type", "state", "stateMetadata", "script"]),
+      ...ObjectUtils_pick(b, fields),
       reuse: b.reuse?.fullName,
     };
     return ObjectUtils_isEqual(pickA, pickB);

--- a/test/planner.test.ts
+++ b/test/planner.test.ts
@@ -851,6 +851,24 @@ Bench Press / ...Squat / progress: custom() {~ ~}
     expect(evaluatedWeeks[0][0].success).to.be.true;
   });
 
+  it("doesn't show an error for same dp progress on exercise with different rep ranges across days", () => {
+    const programText = `# Week 1
+## Day 1
+Front Squat / 3x10-12 / 120s / progress: dp(5lb, 8, 12)
+
+## Day 2
+Front Squat / 3x8 / 120s / progress: dp(5lb, 8, 12)
+`;
+    const planner: IPlannerProgram = {
+      vtype: "planner",
+      name: "MyProgram",
+      weeks: PlannerProgram_evaluateText(programText),
+    };
+    const evaluatedWeeks = PlannerProgram_evaluate(planner, Settings_build()).evaluatedWeeks;
+    expect(evaluatedWeeks[0][0].success).to.be.true;
+    expect(evaluatedWeeks[0][1].success).to.be.true;
+  });
+
   it("doesn't show an error if original exercise update reuses another exercise but overrides update", () => {
     const programText = `# Week 1
 ## Day 1


### PR DESCRIPTION
## Summary
- Fix false "Same property 'progress' is specified with different arguments" error when the same exercise uses `dp()` progress on different days with different rep range formats (e.g., `3x10-12` vs `3x8`)
- Exclude the auto-generated `script` field from `isEqualProgress` comparison for `dp` type, since the script varies based on whether sets have rep ranges — not based on user-specified progress arguments
- Add unit test reproducing the exact scenario from the Rollbar error

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6203/occurrence/455505292588

## Decision
Fixed — this is a real bug affecting normal user flows. When the same exercise appears on multiple days with `dp()` progress and different rep range formats, the program editor throws a validation error blocking the user from editing their program.

## Root Cause
`PlannerEvaluator_fillInMetadata` replaces the `dp` progress script with `buildDpRangeScript()` when an exercise has a rep range (e.g., `3x10-12`), but keeps the default `buildDpScript()` when there's no range (e.g., `3x8`). When `isEqualProgress` then compares the two instances of the same exercise, the `script` field differs even though the user wrote identical `dp(5lb, 8, 12)` arguments, causing a false validation error.

## Test plan
- [x] Unit test added reproducing the exact scenario (same exercise, same dp args, different rep ranges across days)
- [x] All 257 unit tests pass
- [x] Playwright E2E tests pass (only pre-existing flaky subscription test failure)
- [x] TypeScript type check passes
- [ ] Verify in production that programs with same exercise on multiple days with dp() progress and different rep ranges no longer throw errors