### PR TITLE
fix-rollbar (6202/455505098966): handle evaluation errors when finishing workout

### DIFF
--- a/src/models/program.ts
+++ b/src/models/program.ts
@@ -603,6 +603,12 @@ export function Program_runAllFinishDayScripts(
 ): { program: IProgram; exerciseData: IExerciseData } {
   const exerciseData: IExerciseData = {};
   const newEvaluatedProgram = Program_forceEvaluate(program, settings);
+  if (newEvaluatedProgram.errors.length > 0) {
+    const theNextDay = Program_nextDay(newEvaluatedProgram, progress.day);
+    const newProgram = ObjectUtils_clone(program);
+    newProgram.nextDay = theNextDay;
+    return { program: newProgram, exerciseData };
+  }
   const dayData = Progress_getDayData(progress);
   const programDay = Program_getProgramDay(newEvaluatedProgram, progress.day);
   if (!programDay) {


### PR DESCRIPTION
## Summary
- When a program has validation errors (e.g. conflicting progress properties across weeks/days), `Program_runAllFinishDayScripts` now returns early instead of crashing
- The fix checks for evaluation errors after `Program_forceEvaluate` and skips finish day scripts and planner conversion, only advancing `nextDay`
- Workout history is still saved correctly by the caller (`Progress_finishWorkout`)

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6202/occurrence/455505098966

## Decision
Fixed because it affects a core user flow (finishing a workout). The error causes an unhandled exception that blocks users from completing workouts when their program has conflicting properties.

## Root Cause
`Program_forceEvaluate` properly catches `PlannerSyntaxError` (e.g. "Same property 'progress' is specified with different arguments") and stores it in the `errors` array. But `Program_runAllFinishDayScripts` then passes the evaluated program to `ProgramToPlanner.convertToPlanner()`, which checks for errors and re-throws the first one. This re-thrown error is unhandled, causing the crash reported in Rollbar.

## Test plan
- [ ] Verify unit tests pass (256 passing)
- [ ] Verify Playwright E2E tests pass (29 passed, 1 known flaky)
- [ ] Verify build and type check pass