### PR TITLE
fix-rollbar (3602/455496853092): Ignore browser extension runtime.sendMessage error

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -43,6 +43,7 @@ export const exceptionIgnores = [
   "_AutofillCallbackHandler",
   "Incorrect locale information provided",
   "chrome-extension://",
+  "Invalid call to runtime.sendMessage()",
 ];
 
 export async function RollbarUtils_load(item: string | number, token: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Added `"Invalid call to runtime.sendMessage()"` to the Rollbar exception ignore list in `src/utils/rollbar.ts`

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/3602/occurrence/455496853092

## Decision
Added to ignore list. The error `"Invalid call to runtime.sendMessage(). Tab not found."` originates from a browser extension (WebExtension messaging API), not from Liftosaur code. The stack trace has zero frames from our codebase, and the telemetry shows `get-frame-manager-configuration` messages from a masked webkit extension URL. This is not actionable.

## Root Cause
A Safari browser extension on the user's iPhone is calling `runtime.sendMessage()` which throws when the tab context is not available. This error bubbles up to our global error handler and gets reported to Rollbar, but it has nothing to do with Liftosaur code.

## Test plan
- [x] TypeScript type check passes
- [x] Unit tests pass (256 passing)
- [x] Playwright E2E tests pass (30 passed, 1 known flaky failure in subscriptions.spec.ts)
- [x] Verified the ignore string matches the error message pattern