### PR TITLE
fix-rollbar (3743/455587301358): guard Progress_getProgress against undefined in reducer

### DIFF
--- a/src/ducks/reducer.ts
+++ b/src/ducks/reducer.ts
@@ -759,11 +759,22 @@ export const reducer: Reducer<IState, IAction> = (state, action): IState => {
       progress: Progress_isCurrent(progress) ? state.progress : Progress_stop(state.progress, progress.id),
     };
   } else if (action.type === "ChangeDate") {
-    return Progress_setProgress(state, Progress_showUpdateDate(Progress_getProgress(state)!, action.date, action.time));
+    const progress = Progress_getProgress(state);
+    if (progress == null) {
+      return state;
+    }
+    return Progress_setProgress(state, Progress_showUpdateDate(progress, action.date, action.time));
   } else if (action.type === "ConfirmDate") {
-    return Progress_setProgress(state, Progress_changeDate(Progress_getProgress(state)!, action.date, action.time));
+    const progress = Progress_getProgress(state);
+    if (progress == null) {
+      return state;
+    }
+    return Progress_setProgress(state, Progress_changeDate(progress, action.date, action.time));
   } else if (action.type === "CancelProgress") {
-    const progress = Progress_getProgress(state)!;
+    const progress = Progress_getProgress(state);
+    if (progress == null) {
+      return { ...state, screenStack: pushScreen(state.screenStack, "main", undefined, true) };
+    }
     return {
       ...state,
       screenStack: pushScreen(state.screenStack, "main", undefined, true),


### PR DESCRIPTION
## Summary
- Remove non-null assertions (`!`) on `Progress_getProgress()` in the `ChangeDate`, `ConfirmDate`, and `CancelProgress` reducer handlers
- When progress is `undefined` (e.g. after a watch storage merge clears it mid-workout), these handlers now safely return state unchanged or navigate to main, instead of crashing

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/3743/occurrence/455587301358

## Decision
Fixed. The original crash (`undefined is not an object (evaluating 'e.id')`) in `AppView`/`Progress.isCurrent` was already fixed on master by adding `FallbackScreen` and removing the `!` assertion in the render path. However, the reducer still had 3 remaining non-null assertions on `Progress_getProgress()` that could crash under the same race condition (watch storage merge clearing progress while on the workout screen). This PR removes those remaining assertions.

## Root Cause
A watch storage merge (`Thunk_handleWatchStorageMerge`) arrived ~1 second after the user started a workout. The merge used version-based conflict resolution, and the watch's `progress: []` won over the phone's newly created progress. This left `storage.progress` empty while the screen was still on `"progress"`, causing `Progress_getProgress()` to return `undefined`. The old code used `Progress.getProgress(state)!` (non-null assertion) which then crashed when accessing `.id` on `undefined`.

## Test plan
- [x] Build passes (`npm run build:prepare`)
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Unit tests pass (212 passing, 44 pre-existing failures from `__COMMIT_HASH__`)
- [x] Playwright E2E tests pass (29 passed, 1 known flaky `subscriptions.spec.ts`)
- [ ] Verify ChangeDate/ConfirmDate actions are no-ops when progress is undefined
- [ ] Verify CancelProgress navigates to main when progress is undefined