### PR TITLE
fix-rollbar (6229/455579703720): guard localStorage accesses against null

### DIFF
--- a/src/aboutExporter.tsx
+++ b/src/aboutExporter.tsx
@@ -2,12 +2,12 @@ function updateSource(): void {
   const params = new URLSearchParams(window.location.search);
   const source = params.get("cpgsrc");
   if (source) {
-    window.localStorage.setItem("source", source);
+    window.localStorage?.setItem("source", source);
   }
 }
 
 function setStoreParams(): void {
-  const source = window.localStorage.getItem("source");
+  const source = window.localStorage?.getItem("source");
   if (source) {
     for (const link of Array.from(document.querySelectorAll(".google-play-link"))) {
       const href = link.getAttribute("href");

--- a/src/pages/main/mainContent.tsx
+++ b/src/pages/main/mainContent.tsx
@@ -27,9 +27,9 @@ export function MainContent(props: IMainContentProps): JSX.Element {
     const params = new URLSearchParams(window.location.search);
     let source = params.get("cpgsrc");
     if (source) {
-      window.localStorage.setItem("source", source);
+      window.localStorage?.setItem("source", source);
     }
-    source = window.localStorage.getItem("source");
+    source = window.localStorage?.getItem("source") ?? null;
     if (source) {
       for (const link of Array.from(document.querySelectorAll(".google-play-link"))) {
         const href = link.getAttribute("href");

--- a/src/pages/planner/plannerContent.tsx
+++ b/src/pages/planner/plannerContent.tsx
@@ -226,7 +226,7 @@ export function PlannerContent(props: IPlannerContentProps): JSX.Element {
   const planner = state.current.program.planner!;
   useUndoRedo(state, dispatch, [!!state.fulltext], () => state.fulltext == null);
   useEffect(() => {
-    setShowHelp(typeof window !== "undefined" && window.localStorage.getItem("hide-planner-help") !== "true");
+    setShowHelp(typeof window !== "undefined" && window.localStorage?.getItem("hide-planner-help") !== "true");
     if (props.initialProgram) {
       const exportProgram = Program_exportProgram(state.current.program, settings);
       Encoder_encodeIntoUrl(JSON.stringify(exportProgram), window.location.href).then(() => {
@@ -289,7 +289,7 @@ export function PlannerContent(props: IPlannerContentProps): JSX.Element {
               className="block ml-3 nm-planner-help"
               onClick={() => {
                 setShowHelp(true);
-                window.localStorage.removeItem("hide-planner-help");
+                window.localStorage?.removeItem("hide-planner-help");
               }}
             >
               <IconHelp />
@@ -361,7 +361,7 @@ export function PlannerContent(props: IPlannerContentProps): JSX.Element {
             style={{ top: "0.5rem", right: "0.5rem" }}
             onClick={() => {
               setShowHelp(false);
-              window.localStorage.setItem("hide-planner-help", "true");
+              window.localStorage?.setItem("hide-planner-help", "true");
             }}
           >
             <IconCloseCircleOutline />


### PR DESCRIPTION
## Summary
- Add optional chaining (`?.`) to all unprotected `window.localStorage` calls in `plannerContent.tsx`, `mainContent.tsx`, and `aboutExporter.tsx`
- Prevents `TypeError: Cannot read properties of null (reading 'getItem')` when `localStorage` is unavailable (e.g. Android WebView)

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6229/occurrence/455579703720

## Decision
Fixed — the error is in our code, affects a production user on Android WebView, and is straightforward to guard against. Some parts of the codebase already use optional chaining for localStorage (e.g. `platform.ts`) or explicit null checks (e.g. `reducer.ts`), but several call sites were unprotected.

## Root Cause
`window.localStorage` is `null` in certain Android WebView contexts (Pixel 4a, Chrome 145 WebView). The code in `plannerContent.tsx`, `mainContent.tsx`, and `aboutExporter.tsx` called `.getItem()`, `.setItem()`, and `.removeItem()` directly on `window.localStorage` without null-safety, causing a TypeError crash during Preact's `useEffect` hook processing.

## Test plan
- [ ] Verify build passes (`npm run build:prepare`)
- [ ] Verify TypeScript type-check passes (`npx tsc --noEmit`)
- [ ] Verify Playwright E2E tests pass
- [ ] Confirm optional chaining gracefully handles null localStorage (no-op instead of crash)