### PR TITLE
fix-rollbar (6120/455577013529): Guard Markdown callers against undefined description

### DIFF
--- a/src/components/modalProgramInfo.tsx
+++ b/src/components/modalProgramInfo.tsx
@@ -37,7 +37,9 @@ export function ModalProgramInfo(props: IProps): JSX.Element {
           </div>
         </div>
       )}
-      <Markdown value={props.program.description} className="mt-4 text-sm program-description" />
+      {props.program.description && (
+        <Markdown value={props.program.description} className="mt-4 text-sm program-description" />
+      )}
       <p className="mt-6 text-center">
         <Button
           name="preview-program"

--- a/src/pages/programs/programDetailsContent.tsx
+++ b/src/pages/programs/programDetailsContent.tsx
@@ -84,14 +84,16 @@ export function ProgramDetailsContent(props: IProgramDetailsContentProps): JSX.E
               )}
             </div>
           )}
-          <Markdown
-            className="program-details-description"
-            value={descriptionText}
-            directivesData={{
-              exercise: { settings },
-              exerciseExample: { settings, evaluatedProgram },
-            }}
-          />
+          {descriptionText && (
+            <Markdown
+              className="program-details-description"
+              value={descriptionText}
+              directivesData={{
+                exercise: { settings },
+                exerciseExample: { settings, evaluatedProgram },
+              }}
+            />
+          )}
           {props.faq && (
             <Markdown
               className="program-details-description mt-8"


### PR DESCRIPTION
## Summary
- Add null guard in `ModalProgramInfo` before rendering `Markdown` with `props.program.description`
- Add null guard in `ProgramDetailsContent` before rendering `Markdown` with `descriptionText`
- Prevents `markdown-it`'s `md.render()` from receiving `undefined` when program description is missing

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6120/occurrence/455577013529

## Decision
Fixed by adding guards at the call sites. The Markdown component already has a defensive conversion on master (from PR #456), but it hadn't been deployed when this occurrence happened. These call-site guards provide defense-in-depth and avoid rendering empty markdown blocks when description is absent.

## Root Cause
When a user browses the built-in programs list and clicks on a program, `ModalProgramInfo` renders `props.program.description` via the `Markdown` component. If the program's `description` field is undefined (it's optional on `IProgramIndexEntry`), `markdown-it`'s `render()` throws "Input data should be a String". The user was on the built-in programs tab clicking "choose program" when this occurred.

## Test plan
- [ ] Browse built-in programs list and click on a program to verify modal renders correctly
- [ ] Verify programs with descriptions still display properly
- [ ] Verify program details page renders correctly with and without descriptions