### PR TITLE
fix-rollbar (5860/455575747564): Guard against missing warmupSets in migrations

### DIFF
--- a/src/migrations/migrations.ts
+++ b/src/migrations/migrations.ts
@@ -40,7 +40,7 @@ export const migrations = {
         for (const set of entry.sets) {
           set.originalWeight = ObjectUtils_clone(set.weight);
         }
-        for (const set of entry.warmupSets) {
+        for (const set of entry.warmupSets || []) {
           set.originalWeight = ObjectUtils_clone(set.weight);
         }
       }
@@ -303,6 +303,7 @@ export const migrations = {
           set.vtype = set.vtype || "set";
           set.index = set.index ?? setIndex;
         }
+        entry.warmupSets = entry.warmupSets || [];
         for (let setIndex = 0; setIndex < entry.warmupSets.length; setIndex++) {
           const set = entry.warmupSets[setIndex];
           set.vtype = set.vtype || "set";
@@ -341,7 +342,7 @@ export const migrations = {
             set.id = UidFactory_generateUid(6);
           }
         }
-        for (const set of entry.warmupSets) {
+        for (const set of entry.warmupSets || []) {
           if (!set.id) {
             set.id = UidFactory_generateUid(6);
           }
@@ -355,7 +356,7 @@ export const migrations = {
             set.id = UidFactory_generateUid(6);
           }
         }
-        for (const set of entry.warmupSets) {
+        for (const set of entry.warmupSets || []) {
           if (!set.id) {
             set.id = UidFactory_generateUid(6);
           }


### PR DESCRIPTION
## Summary
- Add `|| []` guards to all `entry.warmupSets` iterations in migration functions
- Fixes 4 migration functions: `20240906074315_add_original_weight_to_sets`, `20251231182918_add_vtypes_and_indexes_to_entries_and_sets`, and both history/progress loops in `20260208210220_fill_sets_with_ids`

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/5860/occurrence/455575747564

## Decision
Fixed because this is a real bug that blocks data migrations for users with older history entries that predate the introduction of the `warmupSets` field. When migrations fail, the data stays unmigrated but the version is still bumped to latest, causing subsequent validation errors and potentially broken state.

## Root Cause
Several migration functions iterate over `entry.warmupSets` using `for...of` without guarding against `undefined`. Users with older history data (before `warmupSets` was added to `IHistoryEntry`) don't have this field, causing `TypeError: object is not iterable (cannot read property Symbol(Symbol.iterator))`.

## Test plan
- [ ] Verify build passes (`npm run build:prepare`)
- [ ] Verify TypeScript type check passes (`tsc --noEmit`)
- [ ] Verify Playwright E2E tests pass
- [ ] Verify the fix handles history entries without `warmupSets` gracefully