### PR TITLE
fix-rollbar (949/455569234899): fix crash from Hevy CSV import with missing fields

### DIFF
--- a/src/utils/importFromHevy.ts
+++ b/src/utils/importFromHevy.ts
@@ -320,7 +320,9 @@ export function ImportFromHevy_convertHevyCsvToHistoryRecords(
   historyRecords: IHistoryRecord[];
   customExercises: Record<string, ICustomExercise>;
 } {
-  const hevyRecords = Papa.parse<IHevyRecord>(hevyCsvRaw, { header: true }).data;
+  const hevyRecords = Papa.parse<IHevyRecord>(hevyCsvRaw, { header: true }).data.filter(
+    (r) => r.start_time && r.exercise_title
+  );
 
   const hevyWorkouts: IHevyStruct[] = [];
   for (const workout of ObjectUtils_values(CollectionUtils_groupByKey(hevyRecords, "start_time"))) {
@@ -353,7 +355,7 @@ export function ImportFromHevy_convertHevyCsvToHistoryRecords(
       });
     }
     hevyWorkouts.push({
-      title: workout[0].title,
+      title: workout[0].title || "Workout",
       start_time: workout[0].start_time,
       end_time: workout[0].end_time,
       description: (workout[0].description || "").replace(/\\n/g, "\n"),


### PR DESCRIPTION
## Summary
- Filter out Hevy CSV rows that have empty `exercise_title` or `start_time` fields, preventing invalid records from creating custom exercises with `undefined` name
- Default missing workout `title` to `"Workout"` so `dayName` is never `undefined` in history records

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/949/occurrence/455569234899

## Decision
Fixed because this is a real bug in the Hevy CSV import that causes a TypeError crash (`undefined is not an object (evaluating 'e.replace')`) during rendering. The user imported a Hevy CSV that contained rows with empty exercise titles, which created custom exercises with `name: undefined` and history records with `dayName: undefined`, corrupting the app state.

## Root Cause
Papa.parse can produce rows with empty/undefined fields from trailing newlines or malformed CSV data. The Hevy import code used these fields directly without validation, creating:
1. Custom exercises with `name: undefined` (from empty `exercise_title`)
2. History records with `dayName: undefined` (from empty `title`)

When the app later rendered these records and called `.replace()` or `.toLowerCase()` on the exercise name, it crashed with a TypeError.

## Test plan
- [x] TypeScript type check passes
- [x] Lint passes (pre-existing errors only)
- [x] Unit tests pass (212 passing, 44 pre-existing failures in sync tests)
- [x] Playwright E2E tests pass (27 passed, 5 flaky, 1 pre-existing failure in subscriptions.spec.ts)