### PR TITLE
fix-rollbar (6119/455671037881): Add markdown-it error to ignore list

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -43,6 +43,7 @@ export const exceptionIgnores = [
   "_AutofillCallbackHandler",
   "Incorrect locale information provided",
   "chrome-extension://",
+  "Input data should be a String",
 ];
 
 export async function RollbarUtils_load(item: string | number, token: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Added "Input data should be a String" (markdown-it error) to the Rollbar exception ignore list
- This error was already fixed in commits d562c4bf and 4c7af422 which added non-string guards to the Markdown component
- This occurrence came from a user running stale PWA cached code (version b084d7fa from Feb 20) that didn't have the fix

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6119/occurrence/455671037881

## Decision
Added to ignore list. The root cause was already fixed in two prior PRs that added `typeof` guards and `String()` coercion in `src/components/markdown.tsx`. This occurrence is from a user with a stale PWA cache running old code. Even if it recurs, the markdown-it error is non-critical (display-only, no data loss) and the guard is already in place.

## Root Cause
The `Markdown` component's `props.value` was not a string (likely `undefined` or a non-string type from program description data), causing `markdown-it`'s `md.render()` to throw "Input data should be a String". The fix (coercing to string before calling render) was already deployed.

## Test plan
- [x] Build succeeds
- [x] TypeScript type check passes
- [x] Lint passes (pre-existing errors only)
- [x] Unit tests pass (pre-existing failures only)
- [x] Playwright E2E tests pass (29 passed, 1 flaky subscriptions test)