### PR TITLE
fix-rollbar (5878/455660807464): catch planner syntax errors during workout finish

### DIFF
--- a/src/liftoscriptEvaluator.ts
+++ b/src/liftoscriptEvaluator.ts
@@ -70,6 +70,7 @@ export class LiftoscriptSyntaxError extends SyntaxError {
 
   constructor(message: string, line: number, offset: number, from: number, to: number) {
     super(message);
+    Object.setPrototypeOf(this, LiftoscriptSyntaxError.prototype);
     this.line = line;
     this.offset = offset;
     this.from = from;

--- a/src/models/progress.ts
+++ b/src/models/progress.ts
@@ -1707,7 +1707,12 @@ export function Progress_finishWorkout(storage: IStorage, progress: IHistoryReco
   const settings = storage.settings;
   const programIndex = storage.programs.findIndex((p) => p.id === progress.programId)!;
   const program = progress.programId === emptyProgramId ? Program_createEmptyProgram() : storage.programs[programIndex];
-  const evaluatedProgram = program ? Program_evaluate(program, settings) : undefined;
+  let evaluatedProgram: IEvaluatedProgram | undefined;
+  try {
+    evaluatedProgram = program ? Program_evaluate(program, settings) : undefined;
+  } catch (e) {
+    evaluatedProgram = undefined;
+  }
   Progress_stopTimer(progress);
   const historyRecord = History_finishProgramDay(progress, storage.settings, progress.day, evaluatedProgram);
   let newHistory;
@@ -1717,10 +1722,17 @@ export function Progress_finishWorkout(storage: IStorage, progress: IHistoryReco
     newHistory = [historyRecord, ...storage.history];
   }
   const exerciseData = storage.settings.exerciseData;
-  const { program: newProgram, exerciseData: newExerciseData } =
-    Progress_isCurrent(progress) && program != null
-      ? Program_runAllFinishDayScripts(program, progress, storage.stats, settings)
-      : { program, exerciseData };
+  let finishResult: { program: IProgram | undefined; exerciseData: typeof exerciseData };
+  if (Progress_isCurrent(progress) && program != null) {
+    try {
+      finishResult = Program_runAllFinishDayScripts(program, progress, storage.stats, settings);
+    } catch (e) {
+      finishResult = { program, exerciseData };
+    }
+  } else {
+    finishResult = { program, exerciseData };
+  }
+  const { program: newProgram, exerciseData: newExerciseData } = finishResult;
   const newPrograms = newProgram != null ? lf(storage.programs).i(programIndex).set(newProgram) : storage.programs;
   const newSettingsExerciseData = deepmerge(storage.settings.exerciseData, newExerciseData);
   return {

--- a/src/pages/planner/plannerExerciseEvaluator.ts
+++ b/src/pages/planner/plannerExerciseEvaluator.ts
@@ -83,6 +83,7 @@ export class PlannerSyntaxError extends SyntaxError {
 
   constructor(message: string, line: number, offset: number, from: number, to: number) {
     super(message);
+    Object.setPrototypeOf(this, PlannerSyntaxError.prototype);
     this.line = line;
     this.offset = offset;
     this.from = from;


### PR DESCRIPTION
## Summary
- Add `Object.setPrototypeOf` to `PlannerSyntaxError` and `LiftoscriptSyntaxError` constructors to fix `instanceof` checks that can fail when extending built-in Error classes in some environments
- Wrap `Program_evaluate` and `Program_runAllFinishDayScripts` calls in `Progress_finishWorkout` with try/catch so planner syntax errors don't crash the app and prevent workout completion

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/5878/occurrence/455660807464

## Decision
Fixed because this error crashes the app when a user tries to finish a workout, preventing workout history from being saved. The user's app crashed and restarted after hitting this error.

## Root Cause
A `PlannerSyntaxError` (extending `SyntaxError`) is thrown during planner evaluation when finishing a workout. The `instanceof PlannerSyntaxError` check in the `evaluate()` catch block fails to catch the error — likely due to prototype chain issues with extending built-in Error classes. The uncaught error propagates through the reducer and crashes the app.

Two-part fix:
1. `Object.setPrototypeOf` ensures `instanceof` works reliably for the custom error classes
2. Try/catch in `finishWorkout` ensures that even if evaluation fails, the workout is still saved to history (progression updates are skipped gracefully)

## Test plan
- [ ] Build succeeds, TypeScript type check passes
- [ ] Unit tests pass (212 passing, 44 pre-existing failures unrelated)
- [ ] Playwright E2E tests pass (31 passed, 1 known flaky failure in subscriptions.spec.ts)
- [ ] Verify finishing a workout still works correctly in normal flow
- [ ] Verify that a program with syntax errors doesn't crash when finishing workout