### PR TITLE
fix-rollbar (6248/455650638849): Guard plannerDispatch against missing screen

### DIFF
--- a/src/components/editProgram/screenProgram.tsx
+++ b/src/components/editProgram/screenProgram.tsx
@@ -82,7 +82,8 @@ export function ScreenProgram(props: IProps): JSX.Element {
           undefined
         >
       ).pi("plannerState"),
-      plannerState
+      plannerState,
+      "editProgram"
     ),
     [plannerState]
   );

--- a/src/components/editProgramExercise/editProgramExerciseNavbar.tsx
+++ b/src/components/editProgramExercise/editProgramExerciseNavbar.tsx
@@ -123,7 +123,8 @@ export function EditProgramExerciseNavbar(props: IEditProgramExerciseNavbarProps
                     {}
                   >
                 ).pi("plannerState"),
-                editProgramStateRef.current
+                editProgramStateRef.current,
+                "editProgram"
               );
               plannerDispatch(
                 [lb<IPlannerState>().p("current").p("program").record(stateRef.current.current.program)],

--- a/src/components/editProgramExercise/screenEditProgramExercise.tsx
+++ b/src/components/editProgramExercise/screenEditProgramExercise.tsx
@@ -53,7 +53,8 @@ export function ScreenEditProgramExercise(props: IProps): JSX.Element {
           undefined
         >
       ).pi("plannerState"),
-      plannerState
+      plannerState,
+      "editProgramExercise"
     ),
     [plannerState]
   );

--- a/src/utils/plannerDispatch.ts
+++ b/src/utils/plannerDispatch.ts
@@ -3,16 +3,24 @@ import { IState, updateState } from "../models/state";
 import { IDispatch } from "../ducks/types";
 import { ILensDispatch } from "./useLensReducer";
 import { IUndoRedoState, undoRedoMiddleware } from "../pages/builder/utils/undoredo";
+import { IScreen } from "../models/screen";
 
 export function buildPlannerDispatch<T, S extends IUndoRedoState<T>, O = never>(
   dispatch: IDispatch,
   lensBuilder: LensBuilder<IState, S, {}, O>,
-  plannerState: S
+  plannerState: S,
+  screenName?: IScreen
 ): ILensDispatch<S> {
   const plannerDispatch = (
     lensRecording: ILensRecordingPayload<S> | ILensRecordingPayload<S>[],
     desc: string
   ): void => {
+    if (screenName && window.reducerLastState) {
+      const screenStack = (window.reducerLastState as IState).screenStack;
+      if (!screenStack.some((s) => s.name === screenName)) {
+        return;
+      }
+    }
     const lensRecordings = Array.isArray(lensRecording) ? lensRecording : [lensRecording];
     updateState(
       dispatch,


### PR DESCRIPTION
## Summary
- Add `screenName` parameter to `buildPlannerDispatch` that checks `window.reducerLastState` to verify the target screen still exists in the screen stack before applying lens operations
- Pass screen name from `ScreenEditProgramExercise` (`"editProgramExercise"`), `ScreenProgram` (`"editProgram"`), and the save handler in `EditProgramExerciseNavbar` (`"editProgram"`)
- When the screen is missing, the dispatch is silently dropped instead of crashing

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6248/occurrence/455650638849

## Decision
Fixed — the error affects normal user flows (editing program exercises) and crashes the app when a race condition occurs between screen navigation and planner state dispatches.

## Root Cause
When `editProgramExercise` screen is popped from the stack (e.g. after saving), any pending dispatches through its `plannerDispatch` still reference a lens path containing `findBy("name", "editProgramExercise")`. Since the screen no longer exists in the stack, `findBy` returns `undefined`, and the subsequent property access (`params.plannerState.history`) throws. The lens isn't properly marked as optional in the `findBy → pi` chain, so the optional guard in `lens.then()` doesn't trigger.

The error was reproduced by a user double-clicking the save button on the exercise editor (15:34:55 and 15:34:58), which caused the screen to be popped twice, followed by navigating back and clicking undo on the parent `editProgram` screen.

## Test plan
- [ ] Build succeeds (`npm run build:prepare`)
- [ ] TypeScript type check passes (`tsc --noEmit`)
- [ ] Lint passes on changed files
- [ ] Unit tests pass (212 passing, 44 pre-existing failures)
- [ ] Playwright E2E tests pass (31 passed, 1 known flaky failure in subscriptions.spec.ts)
- [ ] Open exercise editor, make changes, save, navigate back, click undo — should not crash