### PR TITLE
fix-rollbar (6247/455650625377): make findBy lens optional to prevent crash on screen removal

### DIFF
--- a/src/components/editProgram/screenProgram.tsx
+++ b/src/components/editProgram/screenProgram.tsx
@@ -7,7 +7,7 @@ import { Surface } from "../surface";
 import { NavbarView } from "../navbar";
 import { Footer2View } from "../footer2";
 import { ILensDispatch } from "../../utils/useLensReducer";
-import { lb, LensBuilder } from "lens-shmens";
+import { lb, Lens, LensBuilder } from "lens-shmens";
 import { IPlannerState } from "../../pages/planner/models/types";
 import { HelpEditProgramV2 } from "../help/helpEditProgramV2";
 import { useUndoRedo } from "../../pages/builder/utils/undoredo";
@@ -74,14 +74,18 @@ export function ScreenProgram(props: IProps): JSX.Element {
   const plannerDispatch: ILensDispatch<IPlannerState> = useCallback(
     buildPlannerDispatch(
       props.dispatch,
-      (
-        lb<IState>().p("screenStack").findBy("name", "editProgram", true).pi("params") as LensBuilder<
-          IState,
-          { plannerState: IPlannerState },
-          {},
-          undefined
-        >
-      ).pi("plannerState"),
+      (() => {
+        // findBy can return undefined when the screen has been removed (e.g. onBlur fires after navigation)
+        const findByLens = lb<IState>().p("screenStack").findBy("name", "editProgram", true).get();
+        findByLens._optional = true;
+        type IScreenEntry = { params?: { plannerState: IPlannerState } };
+        return (
+          new LensBuilder<IState, IScreenEntry, {}, undefined>(
+            findByLens as unknown as Lens<IState, IScreenEntry>,
+            {}
+          ).pi("params") as LensBuilder<IState, { plannerState: IPlannerState }, {}, undefined>
+        ).pi("plannerState");
+      })(),
       plannerState
     ),
     [plannerState]

--- a/src/components/editProgramExercise/screenEditProgramExercise.tsx
+++ b/src/components/editProgramExercise/screenEditProgramExercise.tsx
@@ -3,7 +3,7 @@ import { IPlannerExerciseState } from "../../pages/planner/models/types";
 import { IDispatch, buildCustomLensDispatch } from "../../ducks/types";
 import { IDayData, ISettings } from "../../types";
 import { INavCommon, IState, updateState } from "../../models/state";
-import { lb, LensBuilder } from "lens-shmens";
+import { lb, Lens, LensBuilder } from "lens-shmens";
 import { useCallback, useState } from "preact/hooks";
 import { useUndoRedo } from "../../pages/builder/utils/undoredo";
 import { ILensDispatch } from "../../utils/useLensReducer";
@@ -45,14 +45,18 @@ export function ScreenEditProgramExercise(props: IProps): JSX.Element {
   const plannerDispatch: ILensDispatch<IPlannerExerciseState> = useCallback(
     buildPlannerDispatch(
       props.dispatch,
-      (
-        lb<IState>().p("screenStack").findBy("name", "editProgramExercise", true).pi("params") as LensBuilder<
-          IState,
-          { plannerState: IPlannerExerciseState },
-          {},
-          undefined
-        >
-      ).pi("plannerState"),
+      (() => {
+        // findBy can return undefined when the screen has been removed (e.g. onBlur fires after navigation)
+        const findByLens = lb<IState>().p("screenStack").findBy("name", "editProgramExercise", true).get();
+        findByLens._optional = true;
+        type IScreenEntry = { params?: { plannerState: IPlannerExerciseState } };
+        return (
+          new LensBuilder<IState, IScreenEntry, {}, undefined>(
+            findByLens as unknown as Lens<IState, IScreenEntry>,
+            {}
+          ).pi("params") as LensBuilder<IState, { plannerState: IPlannerExerciseState }, {}, undefined>
+        ).pi("plannerState");
+      })(),
       plannerState
     ),
     [plannerState]


### PR DESCRIPTION
## Summary
- Mark the `findBy` lens as optional in `screenEditProgramExercise.tsx` and `screenProgram.tsx` so that when a screen is removed from the stack (e.g. via `PullScreen`), deferred `onBlur` handlers don't crash trying to update state through a stale lens path
- Applied the same defensive fix to both `editProgramExercise` and `editProgram` screen dispatchers

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6247/occurrence/455650625377

## Decision
Fixed because this error affects normal user flows — it's triggered by saving/navigating back from the exercise editor, a common user action. The onBlur handler on CodeMirror editors fires after `PullScreen` removes the screen from the stack.

## Root Cause
The `findBy` lens used to locate screens in the stack returns `undefined` when the screen doesn't exist, but was not marked as `_optional`. The subsequent `.pi("params")` creates an optional lens, but the `then()` composition only guards against null/undefined from the *left* (previous) lens. Since `findBy` wasn't optional, the guard never triggered, causing `"undefined is not an object (evaluating 't[e]')"` when accessing properties on the missing screen entry.

The race condition: user saves/navigates back → `PullScreen` removes `editProgramExercise` → CodeMirror `onBlur` fires → `plannerDispatch` tries to update state through the removed screen's lens path → crash.

## Test plan
- [ ] Edit a program exercise, save it, and navigate back quickly — verify no crash
- [ ] Edit program exercise text, and while the editor is focused, hit back — verify no crash
- [ ] All unit tests pass (307 passing)
- [ ] Playwright E2E tests pass (2 known flaky failures unrelated to this change)