### PR TITLE
fix-rollbar (6246/455650600412): Guard Array.from calls against undefined weekAndDays entries

### DIFF
--- a/src/components/editProgramExercise/editProgramExerciseReuseAtWeekDay.tsx
+++ b/src/components/editProgramExercise/editProgramExerciseReuseAtWeekDay.tsx
@@ -26,10 +26,11 @@ export function EditProgramExerciseReuseAtWeekDay(props: IEditProgramExerciseReu
   const currentWeek = reuseCandidate.weekAndDays[plannerExercise.dayData.week];
   const week = reuse.week;
 
+  const weekDays = reuseCandidate.weekAndDays[week ?? plannerExercise.dayData.week];
   const day =
     reuse.exercise?.dayData.dayInWeek ??
-    (week != null || (currentWeek != null && currentWeek.size > 1)
-      ? Array.from(reuseCandidate.weekAndDays[week ?? plannerExercise.dayData.week])[0]
+    ((week != null || (currentWeek != null && currentWeek.size > 1)) && weekDays != null
+      ? Array.from(weekDays)[0]
       : undefined);
 
   return (
@@ -78,7 +79,7 @@ export function EditProgramExerciseReuseAtWeekDay(props: IEditProgramExerciseReu
           );
         }}
       >
-        {Array.from(reuseCandidateWeeksAndDays[week ?? reuse.exercise?.dayData.week ?? 1]).map((d) => {
+        {Array.from(reuseCandidateWeeksAndDays[week ?? reuse.exercise?.dayData.week ?? 1] ?? []).map((d) => {
           return (
             <option value={d} selected={day === d}>
               {d}

--- a/src/components/editProgramExercise/editProgramExerciseReuseDescriptions.tsx
+++ b/src/components/editProgramExercise/editProgramExerciseReuseDescriptions.tsx
@@ -115,9 +115,10 @@ export function EditProgramExerciseReuseDescriptions(props: IEditProgramExercise
                 if (newReuseCandidate) {
                   const currentWeek = newReuseCandidate.weekAndDays[plannerExercise.dayData.week];
                   const week = !currentWeek ? ObjectUtils_keys(newReuseCandidate.weekAndDays)[0] : undefined;
+                  const weekDays = newReuseCandidate.weekAndDays[week ?? plannerExercise.dayData.week];
                   const day =
-                    week != null || (currentWeek != null && currentWeek.size > 1)
-                      ? Array.from(newReuseCandidate.weekAndDays[week ?? plannerExercise.dayData.week])[0]
+                    (week != null || (currentWeek != null && currentWeek.size > 1)) && weekDays != null
+                      ? Array.from(weekDays)[0]
                       : undefined;
                   ex.descriptions = {
                     reuse: {

--- a/src/components/editProgramExercise/editProgramExerciseReuseSets.tsx
+++ b/src/components/editProgramExercise/editProgramExerciseReuseSets.tsx
@@ -136,11 +136,13 @@ export function EditProgramExerciseReuseSetsExercise(props: IEditProgramExercise
                 if (newReuseCandidate) {
                   const currentWeek = newReuseCandidate.weekAndDays[plannerExercise.dayData.week];
                   const week = !currentWeek ? ObjectUtils_keys(newReuseCandidate.weekAndDays)[0] : undefined;
+                  const weekDays = newReuseCandidate.weekAndDays[week ?? plannerExercise.dayData.week];
                   const day =
-                    plannerExercise.key === newReuseCandidate.exercise.key ||
-                    week != null ||
-                    (currentWeek != null && currentWeek.size > 1)
-                      ? Array.from(newReuseCandidate.weekAndDays[week ?? plannerExercise.dayData.week])[0]
+                    (plannerExercise.key === newReuseCandidate.exercise.key ||
+                      week != null ||
+                      (currentWeek != null && currentWeek.size > 1)) &&
+                    weekDays != null
+                      ? Array.from(weekDays)[0]
                       : undefined;
                   ex.reuse = {
                     fullName: newReuseCandidate.exercise.fullName,


### PR DESCRIPTION
## Summary
- Fixed `TypeError: Array.from requires an array-like object - not null or undefined` crash during program exercise editing
- Added null guards before `Array.from()` calls on `weekAndDays` map lookups in 3 reuse components
- The crash occurred when `weekAndDays[key]` returned `undefined` because the week key didn't exist in the map

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6246/occurrence/455650600412

## Decision
Fixed because this is a crash in our code that affects the core program editing flow. Users editing exercises with reuse configurations would hit this error, causing the UI to crash during Preact rendering.

## Root Cause
In `editProgramExerciseReuseAtWeekDay.tsx`, `editProgramExerciseReuseDescriptions.tsx`, and `editProgramExerciseReuseSets.tsx`, `Array.from()` was called on the result of `weekAndDays[key]` without checking if the key existed in the map. When `reuse.week` pointed to a week number not present in `weekAndDays`, or when the fallback key `plannerExercise.dayData.week` wasn't in the map, the lookup returned `undefined` and `Array.from(undefined)` threw a TypeError. This crashed during Preact's render cycle.

## Test plan
- [x] TypeScript type check passes
- [x] Unit tests pass (307 passing)
- [x] Playwright E2E tests pass (28 passed, 2 pre-existing flaky failures unrelated to changes)
- [ ] Manually test exercise reuse week/day selection in program editor