### PR TITLE
fix-rollbar (5888/455646300876): add migration to fix missing custom exercise names

### DIFF
--- a/src/migrations/migrations.ts
+++ b/src/migrations/migrations.ts
@@ -383,4 +383,13 @@ export const migrations = {
     }
     return storage;
   },
+  "20260304171932_fix_custom_exercise_names": (aStorage: IStorage): IStorage => {
+    const storage: IStorage = JSON.parse(JSON.stringify(aStorage));
+    for (const exercise of ObjectUtils_values(storage.settings.exercises)) {
+      if (exercise && !exercise.name) {
+        exercise.name = exercise.id;
+      }
+    }
+    return storage;
+  },
 };


### PR DESCRIPTION
## Summary
- Add storage migration `20260304171932_fix_custom_exercise_names` that sets `name = id` for any custom exercise missing the `name` field

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/5888/occurrence/455646300876

## Decision
Fixed because this is a real data integrity issue affecting normal user flows. The user's server-side storage has a custom exercise (`hibssina`) missing the required `name` field, causing TStorage validation to fail with `corrupted_server_storage` on every sync attempt. This blocks the user from syncing and results in repeated error popups.

## Root Cause
A custom exercise (`hibssina`) was persisted to the server without a `name` field, even though `name` is required by `TCustomExercise` in `src/types.ts:378`. When the server validates storage during sync2 (`lambda/dao/userDao.ts:204`), io-ts decoding fails because `undefined` is not a valid value for the required `name: t.string` field. This likely happened due to an older code version or incomplete data import that didn't enforce the name requirement.

## Test plan
- [x] TypeScript type check passes
- [x] Unit tests pass (307 passing)
- [x] Playwright E2E tests pass (27 passed, 2 unrelated flaky failures in copyWorkoutText and subscriptions)
- [ ] Verify the migration runs without errors on a storage object with a nameless custom exercise
- [ ] Verify the affected user can sync successfully after deploying this fix