### PR TITLE
fix-rollbar (6297/455729792693): ignore third-party weights.map error

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -43,6 +43,7 @@ export const exceptionIgnores = [
   "_AutofillCallbackHandler",
   "Incorrect locale information provided",
   "chrome-extension://",
+  "weights.map is not a function",
 ];
 
 export async function RollbarUtils_load(item: string | number, token: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Added `weights.map is not a function` to the Rollbar exception ignore list in `src/utils/rollbar.ts`

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6297/occurrence/455729792693

## Decision
This error should be ignored because it does not originate from our code. The string `weights.map` does not appear anywhere in our built JavaScript bundles (verified by searching all dist/*.js files). The stack trace has a single frame at `<anonymous>:5:47` with filename `(unknown)`, indicating third-party or browser extension code. The error occurred on the landing page (`/`), not in the app, with third-party scripts active (Reddit pixel, Google Analytics). Only 1 occurrence total.

## Root Cause
The error `weights.map is not a function or its return value is not iterable` comes from a third-party script or browser extension running on the page. The `<anonymous>` filename and `(unknown)` source with a single stack frame confirm this is not from our bundled application code.

## Test plan
- [x] Verified `weights.map` does not exist in any built JS bundle
- [x] TypeScript type check passes
- [x] All 307 unit tests pass
- [x] Playwright E2E: 29 passed, 2 failed (pre-existing flaky timeout issues in subscriptions.spec.ts and copyWorkoutText.spec.ts, unrelated to change)