### PR TITLE
fix-rollbar (6292/455724800904): ignore flatMap browser compat error

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -43,6 +43,7 @@ export const exceptionIgnores = [
   "_AutofillCallbackHandler",
   "Incorrect locale information provided",
   "chrome-extension://",
+  ".flatMap is not a function",
 ];
 
 export async function RollbarUtils_load(item: string | number, token: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Add `.flatMap is not a function` to Rollbar exception ignore list in `src/utils/rollbar.ts`

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6292/occurrence/455724800904

## Decision
Added to ignore list. The error is a browser compatibility issue on a Huawei P30 Pro device with a non-standard WebView that reports Chrome 89 but lacks `Array.prototype.flatMap` support (a standard ES2019 feature available since Chrome 69). Only 1 total occurrence, on the public `/exercises` page — no user data loss or core feature impact.

## Root Cause
`Object.keys(allExercisesList).flatMap(...)` in `Exercise_allExpanded()` (`src/models/exercise.ts`) fails because the Huawei device's WebView engine does not support `Array.prototype.flatMap` despite reporting a Chrome 89 user agent. This is a known issue with some Huawei devices that use custom WebView implementations after the Google/Huawei licensing changes.

## Test plan
- [x] Build succeeds
- [x] TypeScript type check passes
- [x] Lint passes on changed file
- [x] All 307 unit tests pass
- [x] Playwright E2E: 29 passed, 3 flaky (retried OK), 2 pre-existing failures unrelated to change