### PR TITLE
fix-rollbar (6234/455622581078): call Apple Sign-In init() before signIn()

### DIFF
--- a/src/components/account.tsx
+++ b/src/components/account.tsx
@@ -184,6 +184,12 @@ function AccountLoggedOutView(props: IAccountLoggedOutViewProps): JSX.Element {
                   alert("Apple Sign In is not available");
                   return;
                 }
+                window.AppleID.auth.init({
+                  clientId: "com.liftosaur.www.signinapple",
+                  scope: "email",
+                  redirectURI: `${__HOST__}/appleauthcallback.html`,
+                  usePopup: true,
+                });
                 const response = await window.AppleID.auth.signIn();
                 const { id_token, code } = response.authorization;
                 if (id_token != null && code != null) {

--- a/src/ducks/thunks.ts
+++ b/src/ducks/thunks.ts
@@ -128,6 +128,17 @@ export function Thunk_postevent(action: string, extra?: Record<string, string | 
   };
 }
 
+declare let __HOST__: string;
+
+function appleIdInit(): void {
+  window.AppleID?.auth.init({
+    clientId: "com.liftosaur.www.signinapple",
+    scope: "email",
+    redirectURI: `${__HOST__}/appleauthcallback.html`,
+    usePopup: true,
+  });
+}
+
 export function Thunk_appleSignIn(cb?: () => void): IThunk {
   return async (dispatch, getState, env) => {
     dispatch(Thunk_postevent("apple-sign-in"));
@@ -154,6 +165,7 @@ export function Thunk_appleSignIn(cb?: () => void): IThunk {
         }
         return;
       }
+      appleIdInit();
       const response = await window.AppleID.auth.signIn();
       ({ id_token, code } = response.authorization);
     }


### PR DESCRIPTION
## Summary
- Call `AppleID.auth.init()` immediately before `signIn()` in both `thunks.ts` and `account.tsx` to fix a race condition where the Apple JS SDK loads after the component's `useEffect` init call

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6234/occurrence/455622581078

## Decision
Fixed because this error blocks users from signing in with Apple on the login page and account screen.

## Root Cause
The Apple Sign-In JS SDK is loaded with `async` in the HTML. The `useEffect` in `Account` and `ScreenAccount` components calls `window.AppleID?.auth.init()` on mount, but if the Apple script hasn't finished loading yet, the optional chaining silently skips initialization. When the user later clicks "Sign in with Apple", the SDK has loaded but `init()` was never called, causing `signIn()` to throw "The init function must be called first."

The fix ensures `init()` is called right before every `signIn()` call, so even if the initial `useEffect` missed it, the SDK is always properly initialized before use.

## Test plan
- [ ] Verify Apple Sign-In works on login page when Apple SDK loads slowly
- [ ] Verify Apple Sign-In works on account screen
- [ ] Verify no regressions in Google Sign-In flow