### PR TITLE
fix-rollbar (6233/455621621702): catch LensError in UpdateProgress to handle stale entry indices

### DIFF
--- a/src/ducks/reducer.ts
+++ b/src/ducks/reducer.ts
@@ -36,7 +36,7 @@ import {
   Screen_updateParams,
   Screen_pull,
 } from "../models/screen";
-import { ILensRecordingPayload, lb, LensBuilder } from "lens-shmens";
+import { ILensRecordingPayload, lb, LensBuilder, LensError } from "lens-shmens";
 import { buildState, IEnv, ILocalStorage, INotification, IState, IStateErrors, updateState } from "../models/state";
 import { UidFactory_generateUid } from "../utils/generator";
 import {
@@ -678,7 +678,14 @@ export function buildCardsReducer(
         return newProgress;
       }
       case "UpdateProgress": {
-        return action.lensRecordings.reduce((memo, recording) => recording.fn(memo), progress);
+        try {
+          return action.lensRecordings.reduce((memo, recording) => recording.fn(memo), progress);
+        } catch (e) {
+          if (e instanceof LensError) {
+            return progress;
+          }
+          throw e;
+        }
       }
     }
   };

--- a/test/reducer.test.ts
+++ b/test/reducer.test.ts
@@ -1,0 +1,54 @@
+import "mocha";
+import { expect } from "chai";
+import { buildCardsReducer } from "../src/ducks/reducer";
+import { IHistoryRecord } from "../src/types";
+import { Settings_build } from "../src/models/settings";
+import { lb } from "lens-shmens";
+import { UidFactory_generateUid } from "../src/utils/generator";
+
+describe("buildCardsReducer", () => {
+  it("handles UpdateProgress with stale entry index gracefully", () => {
+    const settings = Settings_build();
+    const stats = { weight: {}, length: {}, percentage: {} };
+    const progress: IHistoryRecord = {
+      vtype: "progress",
+      date: new Date().toISOString().slice(0, 10),
+      programId: "test",
+      programName: "Test",
+      day: 1,
+      dayName: "Day 1",
+      startTime: Date.now(),
+      id: 0,
+      entries: [
+        {
+          vtype: "history_entry",
+          index: 0,
+          id: UidFactory_generateUid(6),
+          exercise: { id: "squat" },
+          sets: [
+            {
+              vtype: "set",
+              id: UidFactory_generateUid(6),
+              index: 0,
+              reps: 5,
+              weight: { value: 100, unit: "kg" },
+              isUnilateral: false,
+              originalWeight: { value: 100, unit: "kg" },
+            },
+          ],
+          warmupSets: [],
+        },
+      ],
+    };
+
+    const reducer = buildCardsReducer(settings, stats);
+    const lbSet = lb<IHistoryRecord>().p("entries").i(3).p("sets").i(2);
+    const result = reducer(progress, {
+      type: "UpdateProgress",
+      lensRecordings: [lbSet.recordModify((s) => ({ ...s, completedReps: 5 }))],
+      desc: "blur-weight",
+    });
+
+    expect(result).to.equal(progress);
+  });
+});


### PR DESCRIPTION
## Summary
- Wrap `UpdateProgress` lens recording application in `buildCardsReducer` with a try/catch for `LensError`
- When a stale lens path references a non-existent entry/set (e.g. after exercises are deleted during a workout), gracefully return the unchanged progress instead of crashing
- Add unit test that reproduces the bug scenario

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6233/occurrence/455621621702

## Decision
Fixed because this error affects a normal user flow — editing and deleting exercises during an active workout causes stale blur/input events to crash the app when they reference deleted entry indices.

## Root Cause
When a user deletes exercises from their workout, React components rendered with the old entry index may still have pending blur/input events. When those fire, they dispatch `UpdateProgress` with a lens path like `entries[3].sets[2]`, but the entries array no longer has an element at index 3. The non-optional lens throws a `LensError` which crashes the reducer.

The specific user flow was: started workout → added/deleted exercises → edited weights on remaining exercises → blur event fired with stale entry index 3 → crash.

## Test plan
- [ ] Start a workout with multiple exercises
- [ ] Delete an exercise from the middle of the list
- [ ] Edit weights on the remaining exercises and trigger blur events
- [ ] Verify no crash occurs and weights are saved correctly
- [ ] Finish the workout successfully