### PR TITLE
fix-rollbar (6329/455809851636): catch service worker registration rejection

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -45,7 +45,7 @@ import { DeviceId_get } from "./utils/deviceId";
 IndexedDBUtils_initializeForSafari();
 
 if ("serviceWorker" in navigator && (typeof window === "undefined" || window.location.protocol.startsWith("http"))) {
-  navigator.serviceWorker.register("/webpushr-sw.js");
+  navigator.serviceWorker.register("/webpushr-sw.js").catch(() => {});
 }
 
 console.log(DateUtils_formatYYYYMMDDHHMM(Date.now()));


### PR DESCRIPTION
## Summary
- Add `.catch(() => {})` to `navigator.serviceWorker.register()` call to handle rejection gracefully

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6329/occurrence/455809851636

## Decision
Fixed by catching the unhandled promise rejection. The service worker registration call was not handling its rejection, causing `Error: Rejected` to be reported to Rollbar. This was triggered by the Google-Read-Aloud bot which doesn't support service workers, but the fix prevents noise from any client where service worker registration fails.

## Root Cause
`navigator.serviceWorker.register("/webpushr-sw.js")` returns a Promise that was not being caught. When the registration fails (e.g., in bot/crawler contexts like Google-Read-Aloud), the unhandled promise rejection propagates to Rollbar as `Error: Rejected`. Service worker registration failure is non-critical — the app works fine without it.

## Test plan
- [ ] Verify build passes
- [ ] Verify unit tests pass
- [ ] Verify E2E tests pass
- [ ] Confirm service worker registration still works in normal browsers (no behavioral change for `.catch()` on success)