### PR TITLE
fix-rollbar (6306/455781918711): ignore native storage timeout errors

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -43,6 +43,7 @@ export const exceptionIgnores = [
   "_AutofillCallbackHandler",
   "Incorrect locale information provided",
   "chrome-extension://",
+  "Native storage operation timed out",
 ];
 
 export async function RollbarUtils_load(item: string | number, token: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Add "Native storage operation timed out" to the Rollbar exception ignore list in `src/utils/rollbar.ts`

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6306/occurrence/455781918711

## Decision
Added to ignore list — this is a transient iOS native bridge timeout that doesn't warrant a code fix.

## Root Cause
The `NativeStorage` class in `src/utils/nativeStorage.ts` sends messages to the iOS native layer and sets a 5-second timeout. During app startup, the native message handler may not be ready yet, causing the timeout to fire. This is a race condition between the WebView JavaScript initialization and the iOS native bridge setup. The error occurred ~4.6 seconds after DOMContentLoaded on an iPhone running iOS 26.3 with app version 13.

This is similar to the already-ignored "Function timed out" error. No user state or action data was captured, confirming this happened before the app fully initialized.

## Test plan
- [ ] Verify the string matches the error message format in `nativeStorage.ts:186`
- [ ] Confirm no existing tests break (307 unit tests passing, Playwright E2E passing with only pre-existing flaky failures)