### PR TITLE
fix-rollbar (5890/455599952217): Guard against undefined exerciseData in migrations

### DIFF
--- a/src/migrations/migrations.ts
+++ b/src/migrations/migrations.ts
@@ -74,6 +74,7 @@ export const migrations = {
   },
   "20250305183455_cleanup_custom_exercises": (aStorage: IStorage): IStorage => {
     const storage: IStorage = JSON.parse(JSON.stringify(aStorage));
+    storage.settings.exerciseData = storage.settings.exerciseData || {};
     for (const customExerciseKey of ObjectUtils_keys(storage.settings.exercises)) {
       const customExercise = storage.settings.exercises[customExerciseKey]!;
       delete customExercise.defaultEquipment;
@@ -320,6 +321,7 @@ export const migrations = {
   },
   "20260124114134_convert_muscle_multipliers_to_object": (aStorage: IStorage): IStorage => {
     const storage: IStorage = JSON.parse(JSON.stringify(aStorage));
+    storage.settings.exerciseData = storage.settings.exerciseData || {};
     for (const key of ObjectUtils_keys(storage.settings.exerciseData)) {
       const exerciseData = storage.settings.exerciseData[key];
       if (exerciseData?.muscleMultipliers && Array.isArray(exerciseData.muscleMultipliers)) {


### PR DESCRIPTION
## Summary
- Add null guard for `settings.exerciseData` in migrations `20250305183455_cleanup_custom_exercises` and `20260124114134_convert_muscle_multipliers_to_object`
- These migrations call `ObjectUtils_keys(storage.settings.exerciseData)` which throws `TypeError: Cannot convert undefined or null to object` when `exerciseData` is missing from old storage schemas

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/5890/occurrence/455599952217

## Decision
Fixed because this is a real bug causing persistent sync failures for affected users. The migration crash prevents all subsequent migrations from applying correctly, which causes io-ts validation to fail on every sync attempt (40+ occurrences for this user across multiple days).

## Root Cause
When server-side storage from an older schema version is missing `settings.exerciseData`, the migration `20260124114134_convert_muscle_multipliers_to_object` crashes on `ObjectUtils_keys(undefined)`. The migration runner catches the error but continues, resulting in incomplete migration. The storage then fails io-ts TStorage validation because fields that should have been added by migrations are still missing. This causes both server-side `corrupted_server_storage` errors on sync and client-side validation error reports.

## Test plan
- [ ] Verify unit tests pass (307 passing)
- [ ] Verify Playwright E2E tests pass (28 passed, 4 flaky passed on retry, 2 unrelated failures)
- [ ] Verify the migration handles undefined `exerciseData` without throwing