### PR TITLE
fix-rollbar (5102/455534879531): guard NativeStorage message handler against non-storage messages

### DIFF
--- a/src/utils/nativeStorage.ts
+++ b/src/utils/nativeStorage.ts
@@ -61,8 +61,9 @@ export class NativeStorage {
   constructor() {
     this.pendingRequests = new Map();
     window.addEventListener("message", (event) => {
-      if (event.data != null) {
-        this.handleResponse(event.data);
+      const data = event.data;
+      if (data != null && typeof data === "object" && "requestId" in data) {
+        this.handleResponse(data);
       }
     });
   }


### PR DESCRIPTION
## Summary
- Added type guard in `NativeStorage` constructor's message event listener to validate that `event.data` is a non-null object with a `requestId` property before passing it to `handleResponse`
- Caches `event.data` in a local variable to avoid potential double-read issues in Android WebView

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/5102/occurrence/455534879531

## Decision
Fixed because this is a crash in our code affecting Android production users in a core path (NativeStorage used for data persistence in native apps).

## Root Cause
The `window.message` event listener in `NativeStorage` receives ALL window messages, not just storage responses. The existing guard (`event.data != null`) was insufficient — non-storage messages (from Google Analytics, native WebView layer, or other scripts) could pass the null check but fail when `handleResponse` tries to access `data.requestId` on a non-object or unexpected message payload. On certain Android WebView versions, `event.data` can also return different values on successive property accesses.

## Test plan
- [x] TypeScript compiles without errors
- [x] All 307 unit tests pass
- [x] Playwright E2E: 28 passed, 4 flaky (pre-existing), 2 failed (pre-existing flaky: subscriptions + copyWorkoutText — unrelated to this change)
- [ ] Verify on Android WebView that native storage operations (get/set/delete) still work correctly