### PR TITLE
fix-rollbar (5566/455534879254): Add defensive guard in NativeStorage.handleResponse

### DIFF
--- a/src/utils/nativeStorage.ts
+++ b/src/utils/nativeStorage.ts
@@ -152,7 +152,7 @@ export class NativeStorage {
   }
 
   private handleResponse(data: IStorageResponse): void {
-    if (!data.requestId) {
+    if (typeof data !== "object" || data == null || !data.requestId) {
       return;
     }
 


### PR DESCRIPTION
## Summary
- Add `typeof data !== "object" || data == null` guard in `NativeStorage.handleResponse` to prevent TypeError when non-object data is received via window message events

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/5566/occurrence/455534879254

## Decision
Fixed with a defensive guard. The primary error (`Cannot read properties of null (reading 'type')` in the message handler in `app.tsx`) was already fixed in a prior commit by adding optional chaining (`event.data?.type`). However, the `NativeStorage.handleResponse` method still lacked a type guard — it receives all window message data but assumed `data` is always an object with a `requestId` property. When `data` is a non-object value (e.g. a string from another source like a service worker), it would throw.

## Root Cause
The `NativeStorage` class listens for all `window` `message` events and passes `event.data` to `handleResponse`. The existing guard `if (!data.requestId)` works when `data` is an object (returns `undefined` for missing property), but fails when `data` is `null` or a primitive type. The error occurred on code version `5c97d766` where the constructor also lacked a `null` check (since added). This additional guard in `handleResponse` itself provides defense-in-depth.

## Test plan
- [x] Unit tests pass (307 passing)
- [x] TypeScript type check passes
- [x] Playwright E2E tests pass (27 passed, 2 unrelated failures in copyWorkoutText and subscriptions)
- [x] Build succeeds