### PR TITLE
feat(api): add stats/measurements endpoints (GET/POST/DELETE /api/v1/stats)

### DIFF
--- a/lambda/api/v1.ts
+++ b/lambda/api/v1.ts
@@ -14,7 +14,11 @@ import {
   ApiV1_deleteProgram,
   ApiV1_playground,
   ApiV1_programStats,
+  ApiV1_getStats,
+  ApiV1_createStats,
+  ApiV1_deleteStats,
   IApiError,
+  ICreateStatInput,
 } from "../utils/apiv1";
 import { EventDao } from "../dao/eventDao";
 
@@ -43,6 +47,11 @@ function resultToResponse<T>(
     return apiErrorFromResult(result.error);
   }
   return ResponseUtils_apiJson(status, { data: result.data });
+}
+
+function parseTimestampParam(value: string): number | undefined {
+  const timestamp = Number(value);
+  return Number.isSafeInteger(timestamp) && timestamp > 0 ? timestamp : undefined;
 }
 
 function withApiAuthAndEvent(
@@ -252,5 +261,64 @@ export const postV1ProgramStatsHandler: RouteHandler<
       return apiError(400, "invalid_input", "Missing 'programText' field");
     }
     return resultToResponse(ApiV1_programStats(auth.user, body.programText as string));
+  });
+};
+
+// --- Stats Endpoints ---
+
+export const getV1StatsEndpoint = Endpoint.build("/api/v1/stats", {
+  type: "string?",
+  name: "string?",
+});
+export const getV1StatsHandler: RouteHandler<IPayload, APIGatewayProxyResult, typeof getV1StatsEndpoint> = async ({
+  payload,
+  match: { params },
+}) => {
+  const { event, di } = payload;
+  return withApiAuthAndEvent(event, di, "api-v1-get-stats", async (auth) => {
+    return resultToResponse(await ApiV1_getStats(auth.userId, params, di));
+  });
+};
+
+export const postV1StatsEndpoint = Endpoint.build("/api/v1/stats");
+export const postV1StatsHandler: RouteHandler<IPayload, APIGatewayProxyResult, typeof postV1StatsEndpoint> = async ({
+  payload,
+}) => {
+  const { event, di } = payload;
+  return withApiAuthAndEvent(event, di, "api-v1-create-stats", async (auth) => {
+    const body = getBodyJson(event);
+    if (!body.measurements || !Array.isArray(body.measurements) || body.measurements.length === 0) {
+      return apiError(400, "invalid_input", "Missing 'measurements' array");
+    }
+    return resultToResponse(
+      await ApiV1_createStats(
+        auth.userId,
+        auth.user,
+        body.measurements as ICreateStatInput[],
+        body.timestamp as number | undefined,
+        di
+      ),
+      201
+    );
+  });
+};
+
+export const deleteV1StatsEndpoint = Endpoint.build("/api/v1/stats/:timestamp", { name: "string?" });
+export const deleteV1StatsHandler: RouteHandler<
+  IPayload,
+  APIGatewayProxyResult,
+  typeof deleteV1StatsEndpoint
+> = async ({ payload, match: { params } }) => {
+  const { event, di } = payload;
+  return withApiAuthAndEvent(event, di, "api-v1-delete-stats", async (auth) => {
+    const name = params.name;
+    if (!name) {
+      return apiError(400, "invalid_input", "Missing 'name' query parameter");
+    }
+    const timestamp = parseTimestampParam(params.timestamp);
+    if (timestamp == null) {
+      return apiError(400, "invalid_input", "Invalid timestamp");
+    }
+    return resultToResponse(await ApiV1_deleteStats(auth.userId, auth.user, timestamp, name, di));
   });
 };

--- a/lambda/index.ts
+++ b/lambda/index.ts
@@ -131,6 +131,12 @@ import {
   postV1PlaygroundHandler,
   postV1ProgramStatsEndpoint,
   postV1ProgramStatsHandler,
+  getV1StatsEndpoint,
+  getV1StatsHandler,
+  postV1StatsEndpoint,
+  postV1StatsHandler,
+  deleteV1StatsEndpoint,
+  deleteV1StatsHandler,
 } from "./api/v1";
 import {
   getMcpEndpoint,
@@ -3167,6 +3173,9 @@ export const getRawHandler = (diBuilder: () => IDI): IHandler => {
       .delete(deleteV1ProgramEndpoint, deleteV1ProgramHandler)
       .post(postV1PlaygroundEndpoint, postV1PlaygroundHandler)
       .post(postV1ProgramStatsEndpoint, postV1ProgramStatsHandler)
+      .get(getV1StatsEndpoint, getV1StatsHandler)
+      .post(postV1StatsEndpoint, postV1StatsHandler)
+      .delete(deleteV1StatsEndpoint, deleteV1StatsHandler)
       .get(getMcpEndpoint, getMcpHandler)
       .delete(deleteMcpEndpoint, deleteMcpHandler)
       .post(postMcpEndpoint, postMcpHandler)

--- a/lambda/utils/apiv1.ts
+++ b/lambda/utils/apiv1.ts
@@ -1,5 +1,6 @@
-import { UserDao, ILimitedUserDao } from "../dao/userDao";
+import { UserDao, ILimitedUserDao, userTableNames } from "../dao/userDao";
 import { IDI } from "./di";
+import { Utils_getEnv } from "../utils";
 import { LiftohistorySerializer_serialize } from "../../src/liftohistory/liftohistorySerializer";
 import {
   LiftohistoryDeserializer_deserialize,
@@ -24,6 +25,22 @@ import {
   TExerciseKind,
   availableMuscles,
   exerciseKinds,
+  IStats,
+  IStatsWeight,
+  IStatsLength,
+  IStatsPercentage,
+  IWeight,
+  ILength,
+  IPercentage,
+  IStatsWeightValue,
+  IStatsLengthValue,
+  IStatsPercentageValue,
+  TWeight,
+  TLength,
+  TPercentage,
+  statsWeightDef,
+  statsLengthDef,
+  statsPercentageDef,
 } from "../../src/types";
 import * as t from "io-ts";
 import { UidFactory_generateUid } from "./generator";
@@ -46,6 +63,7 @@ import {
 } from "../../src/pages/planner/models/plannerStatsUtils";
 import { PlannerProgramExercise_sets } from "../../src/pages/planner/models/plannerProgramExercise";
 import { IEither } from "../../src/utils/types";
+import { ObjectUtils_keys } from "../../src/utils/object";
 
 export interface IApiError {
   status: number;
@@ -753,6 +771,282 @@ export async function ApiV1_deleteCustomExercise(
       exercises: updated,
     },
   }));
+
+  return ok({ deleted: true as const });
+}
+
+// --- Stats ---
+
+const validWeightNames = new Set(ObjectUtils_keys(statsWeightDef));
+const validLengthNames = new Set(ObjectUtils_keys(statsLengthDef));
+const validPercentageNames = new Set(ObjectUtils_keys(statsPercentageDef));
+const validTypes = new Set(["weight", "length", "percentage"] as const);
+
+type IStatType = "weight" | "length" | "percentage";
+type IStatValue = IStatsWeightValue | IStatsLengthValue | IStatsPercentageValue;
+
+interface IStatMeasurement {
+  type: string;
+  name: string;
+  value: IWeight | ILength | IPercentage;
+  timestamp: number;
+}
+
+function validateStatType(type: string): type is IStatType {
+  return validTypes.has(type as IStatType);
+}
+
+function validateStatName(type: IStatType, name: string): boolean {
+  switch (type) {
+    case "weight":
+      return validWeightNames.has(name as keyof IStatsWeight);
+    case "length":
+      return validLengthNames.has(name as keyof IStatsLength);
+    case "percentage":
+      return validPercentageNames.has(name as keyof IStatsPercentage);
+  }
+}
+
+function statsToMeasurements(stats: IStats, filters?: { type?: string; name?: string }): IStatMeasurement[] {
+  const measurements: IStatMeasurement[] = [];
+
+  for (const name of ObjectUtils_keys(stats.weight)) {
+    if (filters?.type && filters.type !== "weight") {
+      continue;
+    }
+    if (filters?.name && filters.name !== name) {
+      continue;
+    }
+    for (const entry of stats.weight[name] || []) {
+      measurements.push({ type: "weight", name, value: entry.value, timestamp: entry.timestamp });
+    }
+  }
+
+  for (const name of ObjectUtils_keys(stats.length)) {
+    if (filters?.type && filters.type !== "length") {
+      continue;
+    }
+    if (filters?.name && filters.name !== name) {
+      continue;
+    }
+    for (const entry of stats.length[name] || []) {
+      measurements.push({ type: "length", name, value: entry.value, timestamp: entry.timestamp });
+    }
+  }
+
+  for (const name of ObjectUtils_keys(stats.percentage)) {
+    if (filters?.type && filters.type !== "percentage") {
+      continue;
+    }
+    if (filters?.name && filters.name !== name) {
+      continue;
+    }
+    for (const entry of stats.percentage[name] || []) {
+      measurements.push({ type: "percentage", name, value: entry.value, timestamp: entry.timestamp });
+    }
+  }
+
+  measurements.sort((a, b) => b.timestamp - a.timestamp);
+  return measurements;
+}
+
+export async function ApiV1_getStats(
+  userId: string,
+  params: { type?: string; name?: string },
+  di: IDI
+): Promise<IApiResult<{ measurements: IStatMeasurement[] }>> {
+  const userDao = new UserDao(di);
+  const stats = await userDao.getStatsByUserId(userId);
+  const measurements = statsToMeasurements(stats, params);
+  return ok({ measurements });
+}
+
+export interface ICreateStatInput {
+  type: string;
+  name: string;
+  value: unknown;
+}
+
+interface IParsedStatInput {
+  type: IStatType;
+  name: string;
+  value: IWeight | ILength | IPercentage;
+}
+
+function parseStatTimestamp(timestamp: unknown): IApiResult<number> {
+  if (timestamp == null) {
+    return ok(Date.now());
+  }
+  if (typeof timestamp !== "number" || !Number.isSafeInteger(timestamp) || timestamp <= 0) {
+    return err(400, "invalid_input", "Invalid timestamp");
+  }
+  return ok(timestamp);
+}
+
+function parseStatValue(type: IStatType, value: unknown): IApiResult<IWeight | ILength | IPercentage> {
+  const result =
+    type === "weight" ? TWeight.decode(value) : type === "length" ? TLength.decode(value) : TPercentage.decode(value);
+  if (result._tag === "Left") {
+    return err(400, "invalid_input", `Invalid value for type "${type}"`);
+  }
+  return ok(result.right);
+}
+
+function statsBucket(stats: IStats, type: IStatType): Record<string, IStatValue[] | undefined> {
+  switch (type) {
+    case "weight":
+      return stats.weight as Record<string, IStatValue[] | undefined>;
+    case "length":
+      return stats.length as Record<string, IStatValue[] | undefined>;
+    case "percentage":
+      return stats.percentage as Record<string, IStatValue[] | undefined>;
+  }
+}
+
+function cloneStats(stats: IStats): IStats {
+  return {
+    weight: { ...stats.weight },
+    length: { ...stats.length },
+    percentage: { ...stats.percentage },
+  };
+}
+
+export async function ApiV1_createStats(
+  userId: string,
+  user: ILimitedUserDao,
+  inputs: ICreateStatInput[],
+  timestamp: number | undefined,
+  di: IDI
+): Promise<IApiResult<{ measurements: IStatMeasurement[] }>> {
+  if (!inputs || inputs.length === 0) {
+    return err(400, "invalid_input", "Missing 'measurements' array");
+  }
+
+  const timestampResult = parseStatTimestamp(timestamp);
+  if (!timestampResult.success) {
+    return timestampResult;
+  }
+  const ts = timestampResult.data;
+
+  const parsedInputs: IParsedStatInput[] = [];
+  const dbNames = new Set<string>();
+  for (const input of inputs) {
+    if (input == null || typeof input !== "object") {
+      return err(400, "invalid_input", "Invalid measurement");
+    }
+    if (typeof input.type !== "string" || !validateStatType(input.type)) {
+      return err(400, "invalid_input", `Invalid type "${input.type}". Valid types: weight, length, percentage`);
+    }
+    if (typeof input.name !== "string" || !validateStatName(input.type, input.name)) {
+      const validNames =
+        input.type === "weight"
+          ? [...validWeightNames]
+          : input.type === "length"
+            ? [...validLengthNames]
+            : [...validPercentageNames];
+      return err(
+        400,
+        "invalid_input",
+        `Invalid name "${input.name}" for type "${input.type}". Valid names: ${validNames.join(", ")}`
+      );
+    }
+
+    const valueResult = parseStatValue(input.type, input.value);
+    if (!valueResult.success) {
+      return valueResult;
+    }
+
+    const dbName = `${ts}_${input.name}`;
+    if (dbNames.has(dbName)) {
+      return err(400, "invalid_input", `Duplicate measurement "${input.name}" at timestamp ${ts}`);
+    }
+    dbNames.add(dbName);
+    parsedInputs.push({ type: input.type, name: input.name, value: valueResult.data });
+  }
+
+  const userDao = new UserDao(di);
+  const currentStats = await userDao.getStatsByUserId(userId);
+  const newStats = cloneStats(currentStats);
+  const created: IStatMeasurement[] = [];
+  const statDbItems: {
+    userId: string;
+    name: string;
+    value: IWeight | ILength | IPercentage;
+    timestamp: number;
+    type: IStatType;
+    vtype: string;
+  }[] = [];
+
+  for (const input of parsedInputs) {
+    const stat = { vtype: "stat" as const, value: input.value, timestamp: ts, updatedAt: ts } as IStatValue;
+    const bucket = statsBucket(newStats, input.type);
+    bucket[input.name] = [...(bucket[input.name] || []).filter((entry) => entry.timestamp !== ts), stat];
+    created.push({ type: input.type, name: input.name, value: input.value, timestamp: ts });
+    statDbItems.push({
+      userId,
+      name: `${ts}_${input.name}`,
+      value: input.value,
+      timestamp: ts,
+      type: input.type,
+      vtype: "stat",
+    });
+  }
+
+  const env = Utils_getEnv();
+  user.storage = { ...user.storage, stats: currentStats };
+  await userDao.applyStorageUpdate(user, (old) => ({ ...old, stats: newStats }), [
+    di.dynamo.batchPut({
+      tableName: userTableNames[env].stats,
+      items: statDbItems,
+    }),
+  ]);
+
+  return ok({ measurements: created });
+}
+
+export async function ApiV1_deleteStats(
+  userId: string,
+  user: ILimitedUserDao,
+  timestamp: number,
+  name: string,
+  di: IDI
+): Promise<IApiResult<{ deleted: true }>> {
+  if (!name) {
+    return err(400, "invalid_input", "Missing 'name' query parameter");
+  }
+  const timestampResult = parseStatTimestamp(timestamp);
+  if (!timestampResult.success) {
+    return timestampResult;
+  }
+
+  const userDao = new UserDao(di);
+  const currentStats = await userDao.getStatsByUserId(userId);
+  const newStats = cloneStats(currentStats);
+
+  let found = false;
+  for (const type of ["weight", "length", "percentage"] as const) {
+    const bucket = statsBucket(newStats, type);
+    const entries = bucket[name];
+    if (entries?.some((e) => e.timestamp === timestamp)) {
+      bucket[name] = entries.filter((e) => e.timestamp !== timestamp);
+      found = true;
+      break;
+    }
+  }
+
+  if (!found) {
+    return err(404, "not_found", "Stat not found");
+  }
+
+  const env = Utils_getEnv();
+  const dbName = `${timestamp}_${name}`;
+  user.storage = { ...user.storage, stats: currentStats };
+  await userDao.applyStorageUpdate(user, (old) => ({ ...old, stats: newStats }), [
+    di.dynamo.remove({
+      tableName: userTableNames[env].stats,
+      key: { userId, name: dbName },
+    }),
+  ]);
 
   return ok({ deleted: true as const });
 }

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -452,6 +452,288 @@ Squat / 3x5 / 100lb`;
     });
   });
 
+  describe("stats endpoints", () => {
+    let apiKey: string;
+
+    beforeEach(async () => {
+      const created = await service.createApiKey("Stats Key");
+      apiKey = created!.key;
+    });
+
+    it("returns empty stats", async () => {
+      const result = await handler(buildEvent("GET", "/api/v1/stats", { headers: apiHeaders(apiKey) }), {
+        getRemainingTimeInMillis: () => 10000,
+      });
+      expect(result.statusCode).to.equal(200);
+      const body = parseBody(result);
+      expect(body.data.measurements).to.deep.equal([]);
+    });
+
+    it("creates a bodyweight measurement", async () => {
+      const createResult = await handler(
+        buildEvent("POST", "/api/v1/stats", {
+          headers: apiHeaders(apiKey),
+          body: {
+            measurements: [{ type: "weight", name: "weight", value: { value: 79.5, unit: "kg" } }],
+          },
+        }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+      expect(createResult.statusCode).to.equal(201);
+      const created = parseBody(createResult);
+      expect(created.data.measurements).to.have.length(1);
+      expect(created.data.measurements[0].type).to.equal("weight");
+      expect(created.data.measurements[0].name).to.equal("weight");
+      expect(created.data.measurements[0].value.value).to.equal(79.5);
+      expect(created.data.measurements[0].value.unit).to.equal("kg");
+      expect(created.data.measurements[0].timestamp).to.be.a("number");
+
+      const listResult = await handler(buildEvent("GET", "/api/v1/stats", { headers: apiHeaders(apiKey) }), {
+        getRemainingTimeInMillis: () => 10000,
+      });
+      expect(parseBody(listResult).data.measurements).to.have.length(1);
+    });
+
+    it("creates multiple measurements in one request", async () => {
+      const createResult = await handler(
+        buildEvent("POST", "/api/v1/stats", {
+          headers: apiHeaders(apiKey),
+          body: {
+            measurements: [
+              { type: "weight", name: "weight", value: { value: 79.5, unit: "kg" } },
+              { type: "percentage", name: "bodyfat", value: { value: 15.2, unit: "%" } },
+              { type: "length", name: "waist", value: { value: 84, unit: "cm" } },
+            ],
+          },
+        }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+      expect(createResult.statusCode).to.equal(201);
+      expect(parseBody(createResult).data.measurements).to.have.length(3);
+    });
+
+    it("creates a measurement with explicit timestamp", async () => {
+      const ts = 1700000000000;
+      const createResult = await handler(
+        buildEvent("POST", "/api/v1/stats", {
+          headers: apiHeaders(apiKey),
+          body: {
+            measurements: [{ type: "weight", name: "weight", value: { value: 80, unit: "kg" } }],
+            timestamp: ts,
+          },
+        }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+      expect(createResult.statusCode).to.equal(201);
+      expect(parseBody(createResult).data.measurements[0].timestamp).to.equal(ts);
+    });
+
+    it("updates storage version state when creating a measurement", async () => {
+      const userBefore = await di.dynamo.get<any>({ tableName: userTableNames.prod.users, key: { id: userId } });
+      const originalIdBefore = userBefore.storage.originalId;
+
+      const createResult = await handler(
+        buildEvent("POST", "/api/v1/stats", {
+          headers: apiHeaders(apiKey),
+          body: {
+            measurements: [{ type: "weight", name: "weight", value: { value: 80, unit: "kg" } }],
+          },
+        }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+
+      expect(createResult.statusCode).to.equal(201);
+      const userAfter = await di.dynamo.get<any>({ tableName: userTableNames.prod.users, key: { id: userId } });
+      expect(userAfter.storage.originalId).to.be.greaterThan(originalIdBefore);
+    });
+
+    it("filters stats by type", async () => {
+      await handler(
+        buildEvent("POST", "/api/v1/stats", {
+          headers: apiHeaders(apiKey),
+          body: {
+            measurements: [
+              { type: "weight", name: "weight", value: { value: 79.5, unit: "kg" } },
+              { type: "percentage", name: "bodyfat", value: { value: 15.2, unit: "%" } },
+            ],
+          },
+        }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+
+      const result = await handler(
+        buildEvent("GET", "/api/v1/stats", { headers: apiHeaders(apiKey), qs: { type: "weight" } }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+      expect(result.statusCode).to.equal(200);
+      const body = parseBody(result);
+      expect(body.data.measurements).to.have.length(1);
+      expect(body.data.measurements[0].type).to.equal("weight");
+    });
+
+    it("filters stats by name", async () => {
+      await handler(
+        buildEvent("POST", "/api/v1/stats", {
+          headers: apiHeaders(apiKey),
+          body: {
+            measurements: [
+              { type: "length", name: "waist", value: { value: 84, unit: "cm" } },
+              { type: "length", name: "chest", value: { value: 100, unit: "cm" } },
+            ],
+          },
+        }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+
+      const result = await handler(
+        buildEvent("GET", "/api/v1/stats", { headers: apiHeaders(apiKey), qs: { name: "waist" } }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+      expect(result.statusCode).to.equal(200);
+      expect(parseBody(result).data.measurements).to.have.length(1);
+      expect(parseBody(result).data.measurements[0].name).to.equal("waist");
+    });
+
+    it("deletes a stat by timestamp", async () => {
+      const createResult = await handler(
+        buildEvent("POST", "/api/v1/stats", {
+          headers: apiHeaders(apiKey),
+          body: {
+            measurements: [{ type: "weight", name: "weight", value: { value: 79.5, unit: "kg" } }],
+          },
+        }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+      const ts = parseBody(createResult).data.measurements[0].timestamp;
+      const userBeforeDelete = await di.dynamo.get<any>({ tableName: userTableNames.prod.users, key: { id: userId } });
+      const originalIdBeforeDelete = userBeforeDelete.storage.originalId;
+
+      const deleteResult = await handler(
+        buildEvent("DELETE", `/api/v1/stats/${ts}`, { headers: apiHeaders(apiKey), qs: { name: "weight" } }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+      expect(deleteResult.statusCode).to.equal(200);
+      expect(parseBody(deleteResult).data.deleted).to.equal(true);
+      const userAfterDelete = await di.dynamo.get<any>({ tableName: userTableNames.prod.users, key: { id: userId } });
+      expect(userAfterDelete.storage.originalId).to.be.greaterThan(originalIdBeforeDelete);
+
+      const listResult = await handler(buildEvent("GET", "/api/v1/stats", { headers: apiHeaders(apiKey) }), {
+        getRemainingTimeInMillis: () => 10000,
+      });
+      expect(parseBody(listResult).data.measurements).to.have.length(0);
+    });
+
+    it("returns 400 for invalid type", async () => {
+      const result = await handler(
+        buildEvent("POST", "/api/v1/stats", {
+          headers: apiHeaders(apiKey),
+          body: {
+            measurements: [{ type: "invalid", name: "weight", value: { value: 79.5, unit: "kg" } }],
+          },
+        }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+      expect(result.statusCode).to.equal(400);
+    });
+
+    it("returns 400 for invalid name", async () => {
+      const result = await handler(
+        buildEvent("POST", "/api/v1/stats", {
+          headers: apiHeaders(apiKey),
+          body: {
+            measurements: [{ type: "weight", name: "bicep", value: { value: 79.5, unit: "kg" } }],
+          },
+        }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+      expect(result.statusCode).to.equal(400);
+    });
+
+    it("returns 400 for invalid measurement value", async () => {
+      const result = await handler(
+        buildEvent("POST", "/api/v1/stats", {
+          headers: apiHeaders(apiKey),
+          body: {
+            measurements: [{ type: "percentage", name: "bodyfat", value: { value: 15.2 } }],
+          },
+        }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+      expect(result.statusCode).to.equal(400);
+      expect(parseBody(result).error.message).to.include("Invalid value");
+    });
+
+    it("returns 400 for invalid measurement shape", async () => {
+      const result = await handler(
+        buildEvent("POST", "/api/v1/stats", {
+          headers: apiHeaders(apiKey),
+          body: {
+            measurements: [null],
+          },
+        }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+      expect(result.statusCode).to.equal(400);
+      expect(parseBody(result).error.message).to.include("Invalid measurement");
+    });
+
+    it("returns 400 for duplicate measurements", async () => {
+      const result = await handler(
+        buildEvent("POST", "/api/v1/stats", {
+          headers: apiHeaders(apiKey),
+          body: {
+            timestamp: 1700000000000,
+            measurements: [
+              { type: "weight", name: "weight", value: { value: 79.5, unit: "kg" } },
+              { type: "weight", name: "weight", value: { value: 80.5, unit: "kg" } },
+            ],
+          },
+        }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+      expect(result.statusCode).to.equal(400);
+      expect(parseBody(result).error.message).to.include("Duplicate measurement");
+    });
+
+    it("returns 400 for missing measurements", async () => {
+      const result = await handler(
+        buildEvent("POST", "/api/v1/stats", {
+          headers: apiHeaders(apiKey),
+          body: {},
+        }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+      expect(result.statusCode).to.equal(400);
+    });
+
+    it("returns 400 for delete without name", async () => {
+      const result = await handler(
+        buildEvent("DELETE", "/api/v1/stats/1700000000000", { headers: apiHeaders(apiKey) }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+      expect(result.statusCode).to.equal(400);
+    });
+
+    it("returns 400 for delete with invalid timestamp", async () => {
+      const result = await handler(
+        buildEvent("DELETE", "/api/v1/stats/not-a-timestamp", { headers: apiHeaders(apiKey), qs: { name: "weight" } }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+      expect(result.statusCode).to.equal(400);
+    });
+
+    it("returns 404 for delete of nonexistent stat", async () => {
+      const result = await handler(
+        buildEvent("DELETE", "/api/v1/stats/9999999999999", {
+          headers: apiHeaders(apiKey),
+          qs: { name: "weight" },
+        }),
+        { getRemainingTimeInMillis: () => 10000 }
+      );
+      expect(result.statusCode).to.equal(404);
+    });
+  });
+
   describe("CORS", () => {
     it("returns CORS headers on OPTIONS", async () => {
       const result = await handler(buildEvent("OPTIONS", "/api/v1/history"), { getRemainingTimeInMillis: () => 10000 });


### PR DESCRIPTION
## What

Adds REST API endpoints for managing body measurements — bodyweight, body fat, and body measurements (waist, chest, etc).

| Method | Endpoint | Description |
|--------|----------|-------------|
| `GET` | `/api/v1/stats?type=&name=` | List measurements with optional filters |
| `POST` | `/api/v1/stats` | Create one or more measurements (batch) |
| `DELETE` | `/api/v1/stats/:timestamp?name=` | Delete a measurement |

## Why

The app tracks measurements in the UI and uses bodyweight (`bw`) in programs, but there's no API to write them. This makes it impossible to sync bodyweight from external sources (smart scales, Garmin, etc.) into Liftosaur programmatically.

My use case: Bluetooth scale → Home Assistant → Garmin Connect → fitdata → **Liftosaur** (this endpoint).

## Implementation

- Follows the exact patterns established by the existing history/program endpoints
- Writes directly to the stats DynamoDB table (same as the sync mechanism)
- Validates type (`weight`/`length`/`percentage`) and name against the existing `statsWeightDef`, `statsLengthDef`, `statsPercentageDef` from `types.ts`
- 12 new tests in `test/api.test.ts` covering CRUD, filtering, validation, and error cases

### POST body example

```json
{
  "measurements": [
    { "type": "weight", "name": "weight", "value": { "value": 79.5, "unit": "kg" } },
    { "type": "percentage", "name": "bodyfat", "value": { "value": 15.2 } }
  ],
  "timestamp": 1711612800000
}
```

`timestamp` is optional (defaults to `Date.now()`).

## ⚠️ Honest disclaimer

This was vibe-coded with AI assistance, so it warrants close review. I've read through the codebase and tried to match conventions, but I don't have the full context of the project that you do. Happy to iterate on feedback.

Really this is a polite feature request as much as a PR — if you'd prefer a different API shape, different endpoint naming, or want to handle the sync/versioning differently, I'm all ears. The core ask is just: a way to write measurements via the API. 🙏