### PR TITLE
Fix Invalid Date for API-created history records

### DIFF
--- a/src/liftohistory/liftohistoryDeserializer.ts
+++ b/src/liftohistory/liftohistoryDeserializer.ts
@@ -211,7 +211,7 @@ function deserializeWorkoutRecord(
 
   return {
     vtype: "history_record",
-    date: dateStr,
+    date: parsedDate.toISOString(),
     programId,
     programName: programName || "Adhoc",
     day,


### PR DESCRIPTION
## Summary

History records created via the MCP API (`create_history_record` / `update_history_record`) display "Invalid Date" on iOS Safari/WebKit.

**Root cause:** The `date` field in `LiftohistoryDeserializer` stores the raw Liftohistory text format:
```
"2026-02-28 10:45:30 +00:00"  (space separator)
```

iOS Safari's `Date.parse()` requires strict ISO 8601 with the `T` separator and returns `NaN` for space-separated date strings, causing "Invalid Date" in the UI.

**Fix:** Use `parsedDate.toISOString()` (which is already a correctly parsed `Date` object on line 138) to store:
```
"2026-02-28T10:45:30.000Z"  (strict ISO 8601)
```

This matches what the app stores when creating records through the normal UI flow (`Program.createHistory`, `Progress.changeDate`).

## Reproduction

1. Create a history record via the MCP API:
   ```
   2026-03-29T01:37:57Z / duration: 1800s / exercises: {
     Bench Press / 3x8 185lb
   }
   ```
2. View the record in the Liftosaur iOS app
3. The workout date displays as "Invalid Date"

## Change

One-line change in `src/liftohistory/liftohistoryDeserializer.ts`:
```diff
-    date: dateStr,
+    date: parsedDate.toISOString(),
```