### PR TITLE
fix-rollbar (4/464836142572): ignore popup_closed_by_user errors

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -48,6 +48,7 @@ export const exceptionIgnores = [
   "_AutofillCallbackHandler",
   "Incorrect locale information provided",
   "chrome-extension://",
+  "popup_closed_by_user",
 ];
 
 export async function RollbarUtils_load(item: string | number, token: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Add `popup_closed_by_user` to the Rollbar exception ignore list in `src/utils/rollbar.ts`

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/4/occurrence/464836142572

## Decision
Added to ignore list. This error is triggered when a user initiates Google OAuth sign-in and closes the popup before completing the flow. It is expected user behavior, not a bug — the error has no actionable stack trace (single `(unknown)` frame), doesn't affect functionality, and doesn't cause data loss.

## Root Cause
Google's OAuth library throws a `popup_closed_by_user` error when the authentication popup is dismissed by the user before the sign-in flow completes. The telemetry shows the user was on the `/affiliates` page, clicked a sign-up button, and then closed the popup.

## Test plan
- [ ] Verify build succeeds
- [ ] Verify unit tests pass (803 passing)
- [ ] Confirm the string matches the Rollbar error message format `{"error":"popup_closed_by_user"}`