### PR TITLE
fix-rollbar (6961/464833464367): ignore webpack module resolution error

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -48,6 +48,7 @@ export const exceptionIgnores = [
   "_AutofillCallbackHandler",
   "Incorrect locale information provided",
   "chrome-extension://",
+  "s[e].call",
 ];
 
 export async function RollbarUtils_load(item: string | number, token: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Added `s[e].call` to the Rollbar exception ignore list to suppress webpack module resolution errors

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6961/occurrence/464833464367

## Decision
Added to ignore list because this is a webpack module loader error (`s[e].call` where `s` is the modules registry), not an application code bug. It occurs when the iOS app loads a stale/cached bundle where webpack module IDs have shifted between builds. The error has 228 occurrences, all from the iOS native app (`liftosaur://` URL scheme), with no user state captured. Not actionable in application code.

## Root Cause
Webpack module resolution failure — the bundled `app.js` tries to call `s[e].call(...)` where module ID `e` doesn't exist in the modules object `s`. This happens when cached/stale bundles contain module IDs that no longer match the current build's module registry, typically due to iOS WebView caching between app updates.

## Test plan
- [ ] Verify build passes
- [ ] Verify unit tests pass
- [ ] Verify the ignore string matches the error message substring