### PR TITLE
fix-rollbar (6648/464832638266): Fix React hydration mismatch in payments dashboard

### DIFF
--- a/lambda/index.ts
+++ b/lambda/index.ts
@@ -1870,18 +1870,20 @@ interface IPaymentsPage {
   paymentsData: IPaymentsDashboardData[];
   userAffiliates: Partial<Record<string, IPaymentsDashboardUserAffiliate>>;
   summary: IPaymentsSummary;
+  serverTimestamp: number;
   nextBefore: number;
   hasMore: boolean;
 }
 
 async function buildPaymentsPage(di: IDI, before: number | undefined, months: number): Promise<IPaymentsPage> {
   const allPayments = (await new PaymentDao(di).getAllPayments()).filter((p) => !p.isTest);
-  const summary = computePaymentsSummary([{ date: "all", payments: allPayments }]);
+  const serverTimestamp = Date.now();
+  const summary = computePaymentsSummary([{ date: "all", payments: allPayments }], serverTimestamp);
 
   const start =
     before != null
       ? DateUtils_addUTCMonths(before, -months)
-      : DateUtils_addUTCMonths(DateUtils_startOfUTCMonth(Date.now()), -(months - 1));
+      : DateUtils_addUTCMonths(DateUtils_startOfUTCMonth(serverTimestamp), -(months - 1));
 
   const windowed = allPayments.filter((p) => p.timestamp >= start && (before == null || p.timestamp < before));
   const hasMore = allPayments.some((p) => p.timestamp < start);
@@ -1919,7 +1921,7 @@ async function buildPaymentsPage(di: IDI, before: number | undefined, months: nu
     }
   }
 
-  return { paymentsData, userAffiliates, summary, nextBefore: start, hasMore };
+  return { paymentsData, userAffiliates, summary, serverTimestamp, nextBefore: start, hasMore };
 }
 
 const getDashboardsPaymentsEndpoint = Endpoint.build("/dashboards/payments", {
@@ -1949,6 +1951,7 @@ const getDashboardsPaymentsHandler: RouteHandler<
       page.paymentsData,
       page.userAffiliates,
       page.summary,
+      page.serverTimestamp,
       page.nextBefore,
       page.hasMore
     ),

--- a/lambda/paymentsDashboard.tsx
+++ b/lambda/paymentsDashboard.tsx
@@ -41,6 +41,7 @@ export function renderPaymentsDashboardHtml(
   paymentsData: IPaymentsDashboardData[],
   userAffiliates: Partial<Record<string, IPaymentsDashboardUserAffiliate>>,
   summary: IPaymentsSummary,
+  serverTimestamp: number,
   nextBefore: number,
   hasMore: boolean
 ): string {
@@ -51,6 +52,7 @@ export function renderPaymentsDashboardHtml(
       paymentsData={paymentsData}
       userAffiliates={userAffiliates}
       summary={summary}
+      serverTimestamp={serverTimestamp}
       nextBefore={nextBefore}
       hasMore={hasMore}
     />

--- a/src/pages/paymentsDashboard/paymentsDashboardContent.tsx
+++ b/src/pages/paymentsDashboard/paymentsDashboardContent.tsx
@@ -16,6 +16,7 @@ export interface IPaymentsDashboardContentProps {
   paymentsData: IPaymentsDashboardData[];
   userAffiliates: Partial<Record<string, IPaymentsDashboardUserAffiliate>>;
   summary: IPaymentsSummary;
+  serverTimestamp: number;
   nextBefore: number;
   hasMore: boolean;
 }
@@ -27,7 +28,7 @@ interface IPaymentsPage {
   hasMore: boolean;
 }
 
-export function computePaymentsSummary(paymentsData: IPaymentsDashboardData[]): IPaymentsSummary {
+export function computePaymentsSummary(paymentsData: IPaymentsDashboardData[], now?: number): IPaymentsSummary {
   const currencyTotals: Record<string, { total: number; refunds: number }> = {};
   const totalsByTypeAndCurrency: Record<string, { subscription: number; inapp: number }> = {};
   const totalsByPlatformAndCurrency: Record<string, { apple: number; google: number }> = {};
@@ -126,7 +127,7 @@ export function computePaymentsSummary(paymentsData: IPaymentsDashboardData[]): 
     });
   });
 
-  const cancellationData = detectCancellations(paymentsData);
+  const cancellationData = detectCancellations(paymentsData, now ?? Date.now());
 
   return {
     currencyTotals,
@@ -203,14 +204,16 @@ interface IUserSubscriptionInfo {
   wasTrialPayment: boolean;
 }
 
-function detectCancellations(paymentsData: IPaymentsDashboardData[]): {
+function detectCancellations(
+  paymentsData: IPaymentsDashboardData[],
+  now: number
+): {
   cancellations: IUserSubscriptionInfo[];
   totalCancellations: number;
   monthlyCancellations: number;
   yearlyCancellations: number;
 } {
   const userSubscriptions = new Map<string, IUserSubscriptionInfo>();
-  const now = Date.now();
 
   paymentsData.forEach((dayData) => {
     dayData.payments.forEach((payment) => {
@@ -414,7 +417,7 @@ export function PaymentsDashboardContent(props: IPaymentsDashboardContentProps):
 
   const summary = props.summary;
 
-  const cancellationData = detectCancellations(paymentsData);
+  const cancellationData = detectCancellations(paymentsData, props.serverTimestamp);
   const cancellationsByPeriod = groupCancellationsByPeriod(cancellationData.cancellations, viewMode);
 
   const cancelledTrialUserIds = new Set(

--- a/src/pages/paymentsDashboard/paymentsDashboardHtml.tsx
+++ b/src/pages/paymentsDashboard/paymentsDashboardHtml.tsx
@@ -11,6 +11,7 @@ export interface IPaymentsDashboardHtmlProps {
   paymentsData: IPaymentsDashboardData[];
   userAffiliates: Partial<Record<string, IPaymentsDashboardUserAffiliate>>;
   summary: IPaymentsSummary;
+  serverTimestamp: number;
   apiKey: string;
   client: Window["fetch"];
   nextBefore: number;


### PR DESCRIPTION
## Summary
- `detectCancellations()` in the payments dashboard used `Date.now()` which produced different results on server (during SSR) vs client (during hydration), causing React error #418 (hydration mismatch)
- Added a `serverTimestamp` prop that captures the timestamp during server rendering and passes it through to the client, ensuring both server and client use the same reference time for cancellation detection

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6648/occurrence/464832638266

## Decision
Fixed because this is a real bug in our SSR/hydration code that affects a production page (payments dashboard). The root cause is deterministic and affects every page load where a subscription's expected renewal timestamp falls near the current time.

## Root Cause
`detectCancellations()` compares each subscription's `expectedRenewalTimestamp` against `Date.now()`. During SSR, the server calls this with its current time. During client hydration (seconds later), the client calls it with a different `Date.now()`. If any subscription's renewal timestamp falls between these two values, the cancellation list differs, producing different HTML and triggering React error #418.

## Test plan
- [ ] Verify the payments dashboard loads without hydration errors
- [ ] Verify cancellation counts display correctly in the summary and per-period sections
- [ ] Verify "Load More" still works and newly loaded data shows cancellations