### PR TITLE
fix-rollbar (7152/464898592250): call AppleID.auth.init() before signIn()

### DIFF
--- a/src/components/account.tsx
+++ b/src/components/account.tsx
@@ -209,6 +209,12 @@ function AccountLoggedOutView(props: IAccountLoggedOutViewProps): JSX.Element {
                 setIsLoading(false);
                 return;
               }
+              window.AppleID.auth.init({
+                clientId: "com.liftosaur.www.signinapple",
+                scope: "email",
+                redirectURI: `${__HOST__}/appleauthcallback.html`,
+                usePopup: true,
+              });
               const response = await window.AppleID.auth.signIn();
               const { id_token, code } = response.authorization;
               if (id_token != null && code != null) {

--- a/src/ducks/thunks.ts
+++ b/src/ducks/thunks.ts
@@ -152,6 +152,7 @@ import { NativeWatchBridge_sendAuthToWatch, NativeWatchBridge_sendClearAuthToWat
 import { Analytics_trackPurchase, Analytics_trackSignUp } from "../utils/analytics";
 
 declare let Rollbar: RB;
+declare let __HOST__: string;
 
 export class NoRetryError extends Error {
   public noretry = true;
@@ -255,6 +256,12 @@ export function Thunk_appleSignIn(cb?: (state: IState) => void): IThunk {
         }
         return;
       }
+      window.AppleID.auth.init({
+        clientId: "com.liftosaur.www.signinapple",
+        scope: "email",
+        redirectURI: `${__HOST__}/appleauthcallback.html`,
+        usePopup: true,
+      });
       const response = await window.AppleID.auth.signIn();
       ({ id_token, code } = response.authorization);
     }


### PR DESCRIPTION
## Summary
- Call `AppleID.auth.init()` immediately before `signIn()` in both direct Apple sign-in paths to fix a race condition where the Apple SDK script loads asynchronously but `useEffect`-based `init()` fires too early (before the SDK is available)

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/7152/occurrence/464898592250

## Decision
Fixed because this affects a normal user flow (Apple Sign In) on production web pages (doc pages with top nav account modal). The error is reproducible when the Apple SDK script loads after the React component mounts.

## Root Cause
The Apple ID SDK script is loaded with `async` attribute. The `useEffect` in `AccountLoggedOutView` calls `window.AppleID.auth.init()` on mount, but if the script hasn't loaded yet at mount time, the `init()` call is skipped (guarded by `window.AppleID?.auth` check). When the user later clicks "Sign in with Apple", the SDK exists but was never initialized, causing `signIn()` to throw "The init function must be called first."

The fix ensures `init()` is always called right before `signIn()` — Apple's SDK is idempotent for `init()` so calling it multiple times is safe.

## Test plan
- [ ] Click "Sign in with Apple" on a doc page's account modal immediately after page load
- [ ] Verify no "init function must be called first" error
- [ ] Verify Apple sign-in popup appears correctly