### PR TITLE
fix-rollbar (7314/464895496640): Ignore @layer CSS rule parse error from old browsers

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -48,6 +48,7 @@ export const exceptionIgnores = [
   "_AutofillCallbackHandler",
   "Incorrect locale information provided",
   "chrome-extension://",
+  "Failed to parse the rule '@layer",
 ];
 
 export async function RollbarUtils_load(item: string | number, token: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Added `Failed to parse the rule '@layer` to the Rollbar exception ignore list
- This error occurs on ancient browsers (Chrome 80, Feb 2020) that don't support CSS `@layer` rules

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/7314/occurrence/464895496640

## Decision
Added to ignore list because this is a browser compatibility issue with an extremely old browser (Chrome 80 on Android 10). CSS `@layer` was introduced in Chrome 99 (March 2022). The error originates from third-party code (uniwind/react-native-web) during stylesheet initialization, and we cannot reasonably support browsers that are 4+ years outdated.

## Root Cause
The `uniwind` library (used by react-native-web) calls `sheet.insertRule("@layer rnw {}", 0)` during CSS stylesheet initialization. Chrome 80 does not support CSS `@layer` rules (introduced in Chrome 99), causing a `SyntaxError`.

## Test plan
- [ ] Verify the error no longer appears in Rollbar for new occurrences from old browsers
- [ ] Confirm no legitimate errors are being suppressed (the ignore string is specific to @layer parsing)