### PR TITLE
fix-rollbar (7424/464894116637): guard undefined week in playground handleFinish

### DIFF
--- a/src/components/preview/programPreviewPlayground.tsx
+++ b/src/components/preview/programPreviewPlayground.tsx
@@ -319,7 +319,10 @@ function ProgramPreviewPlaygroundInner(p: IProgramPreviewPlaygroundInnerProps): 
     (weekIndex: number, dayIndex: number) => {
       const s = stateRef.current;
       const pp = propsRef.current;
-      const d = s.progresses[weekIndex].days[dayIndex];
+      const d = s.progresses[weekIndex]?.days[dayIndex];
+      if (!d) {
+        return;
+      }
       onFinish(dispatch, pp, s, d);
     },
     [dispatch]


### PR DESCRIPTION
## Summary
- Add optional chaining (`?.`) and early return guard to `handleFinish` in `programPreviewPlayground.tsx` to prevent crash when `progresses[weekIndex]` is undefined

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/7424/occurrence/464894116637

## Decision
Fixed — the error is in our code and crashes the app during normal program preview/playground usage on Android.

## Root Cause
In `ProgramPreviewPlayground`, the `handleFinish` callback accesses `s.progresses[weekIndex].days[dayIndex]` without checking if `s.progresses[weekIndex]` exists. On Android (React Native), the `PagerView` can fire callbacks with a `weekIndex` that is momentarily out of sync with the `progresses` array during state updates, causing `s.progresses[weekIndex]` to be `undefined` and the `.days` access to throw a TypeError.

Other code paths in the codebase already use optional chaining for the same access pattern (e.g., `navModalPlaygroundUtils.ts`, `NavModalPlaygroundEditExercise.tsx`, `usePlaygroundModalBridges.ts`).

## Test plan
- [ ] Unit tests pass (803/803)
- [ ] Build succeeds
- [ ] TypeScript type check passes (no new errors)
- [ ] Verify playground week swiping on Android does not crash