### PR TITLE
fix-rollbar (3602/464948253396): Ignore browser extension runtime.sendMessage error

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -48,6 +48,7 @@ export const exceptionIgnores = [
   "_AutofillCallbackHandler",
   "Incorrect locale information provided",
   "chrome-extension://",
+  "Invalid call to runtime.sendMessage()",
 ];
 
 export async function RollbarUtils_load(item: string | number, token: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Added `"Invalid call to runtime.sendMessage()"` to the Rollbar exception ignore list in `src/utils/rollbar.ts`

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/3602/occurrence/464948253396

## Decision
Added to ignore list. The error originates from a browser extension's `runtime.sendMessage()` API call (WebExtensions messaging API). The stack trace has zero frames from our code, there's no associated user state or person, and it's not actionable.

## Root Cause
A browser extension on the user's iPhone Safari attempted to send a message to a tab that no longer existed. This is entirely outside our control — `runtime.sendMessage()` is a browser extension API, not part of our codebase.

## Test plan
- [ ] Verify the string matches the Rollbar error message
- [ ] Confirm no regressions in unit tests (804 passing)