### PR TITLE
fix-rollbar (7266/464932643616): Guard against undefined week in exercise editor

### DIFF
--- a/src/components/editProgram/editProgramUi/editProgramUiHelpers.ts
+++ b/src/components/editProgram/editProgramUi/editProgramUiHelpers.ts
@@ -264,10 +264,10 @@ export function EditProgramUiHelpers_getWeeks2(
   fullName: string,
   ignoreRepeats: boolean = false
 ): number[] {
-  const day = evaluatedProgram.weeks[dayData.week - 1].days[dayData.dayInWeek - 1];
+  const day = evaluatedProgram.weeks[dayData.week - 1]?.days[dayData.dayInWeek - 1];
   const weeks: Set<number> = new Set();
   weeks.add(dayData.week);
-  const exercise = day.exercises.find((e) => e.fullName === fullName);
+  const exercise = day?.exercises.find((e) => e.fullName === fullName);
   if (!ignoreRepeats && exercise != null) {
     for (const repeating of exercise.repeating) {
       weeks.add(repeating);

--- a/src/components/editProgramExercise/editProgramExerciseAcrossAllWeeks.tsx
+++ b/src/components/editProgramExercise/editProgramExerciseAcrossAllWeeks.tsx
@@ -207,8 +207,8 @@ function Tab(props: ITabProps): JSX.Element {
     <View className="px-4">
       {Object.entries(groups).map(([key, group]) => {
         const first = group[0];
-        const day = props.evaluatedProgram.weeks[first.week - 1].days[first.dayInWeek - 1];
-        const exercise = Program_getProgramExerciseFromDay(day, props.plannerExercise.key);
+        const day = props.evaluatedProgram.weeks[first.week - 1]?.days[first.dayInWeek - 1];
+        const exercise = day ? Program_getProgramExerciseFromDay(day, props.plannerExercise.key) : undefined;
         if (!exercise) {
           return (
             <View key={key}>
@@ -216,7 +216,10 @@ function Tab(props: ITabProps): JSX.Element {
             </View>
           );
         }
-        const set = exercise.evaluatedSetVariations[first.setVariation - 1].sets[first.set - 1];
+        const set = exercise.evaluatedSetVariations[first.setVariation - 1]?.sets[first.set - 1];
+        if (!set) {
+          return null;
+        }
         return (
           <View
             key={key}

--- a/src/components/editProgramExercise/editProgramExerciseDay.tsx
+++ b/src/components/editProgramExercise/editProgramExerciseDay.tsx
@@ -33,7 +33,7 @@ interface IEditProgramExerciseDayProps {
 }
 
 export function EditProgramExerciseDay(props: IEditProgramExerciseDayProps): JSX.Element {
-  const day = props.evaluatedProgram.weeks[props.weekIndex].days[props.dayInWeekIndex];
+  const day = props.evaluatedProgram.weeks[props.weekIndex]?.days[props.dayInWeekIndex];
   const plannerExercise = day?.exercises.find((exercise) => exercise.key === props.exerciseKey);
   const hasSetVariations = (plannerExercise?.evaluatedSetVariations.length ?? 0) > 1;
   const lbProgram = lb<IPlannerExerciseState>().p("current").p("program").pi("planner");

--- a/src/components/editProgramExercise/editProgramExerciseDaysList.tsx
+++ b/src/components/editProgramExercise/editProgramExerciseDaysList.tsx
@@ -20,7 +20,11 @@ interface IEditProgramExerciseDaysListProps {
 }
 
 export function EditProgramExerciseDaysList(props: IEditProgramExerciseDaysListProps): JSX.Element {
-  const days = props.evaluatedProgram.weeks[props.weekIndex].days;
+  const week = props.evaluatedProgram.weeks[props.weekIndex];
+  if (!week) {
+    return <View />;
+  }
+  const days = week.days;
 
   return (
     <View>

--- a/src/components/editProgramExercise/screenEditProgramExercise.tsx
+++ b/src/components/editProgramExercise/screenEditProgramExercise.tsx
@@ -60,7 +60,7 @@ export function ScreenEditProgramExercise(props: IProps): JSX.Element {
   const evaluatedProgram = Program_evaluateCachedPlanner(plannerState.current.program, props.settings);
   let plannerExercise = evaluatedProgram.weeks[props.dayData.week - 1]?.days[
     props.dayData.dayInWeek - 1
-  ].exercises.find((e) => e.key === props.exerciseKey);
+  ]?.exercises.find((e) => e.key === props.exerciseKey);
 
   if (!plannerExercise) {
     plannerExercise = Program_getFirstProgramExercise(evaluatedProgram, props.exerciseKey);


### PR DESCRIPTION
## Summary
- Add defensive null checks when accessing `evaluatedProgram.weeks[index].days` in exercise editing UI components
- Protect against stale week/day indices that reference positions no longer existing in the re-evaluated program
- Affected files: `screenEditProgramExercise.tsx`, `editProgramExerciseDay.tsx`, `editProgramExerciseDaysList.tsx`, `editProgramExerciseAcrossAllWeeks.tsx`, `editProgramUiHelpers.ts`

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/7266/occurrence/464932643616

## Decision
Fixed — the error has 230 occurrences in production on Android, affects normal user flows (editing exercise programs), and the fix is minimal defensive null checking.

## Root Cause
When a user edits a program exercise on Android (React Native), state changes can cause the evaluated program to be recomputed with a different week/day structure. Components that access `evaluatedProgram.weeks[index].days` without null guards crash with "Cannot read property 'days' of undefined" when the index points to a week that no longer exists in the re-evaluated program.

## Test plan
- [ ] Edit a program exercise with multiple weeks
- [ ] Delete a week while on the exercise editing screen
- [ ] Verify no crash occurs and the UI recovers gracefully
- [ ] Unit tests pass (804 passing)
- [ ] Build succeeds