### PR TITLE
fix-rollbar (7963/464931288735): ignore Android Magnifier NullPointerException

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -48,6 +48,7 @@ export const exceptionIgnores = [
   "_AutofillCallbackHandler",
   "Incorrect locale information provided",
   "chrome-extension://",
+  "android.widget.Magnifier",
 ];
 
 export async function RollbarUtils_load(item: string | number, token: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Add `android.widget.Magnifier` to the Rollbar exception ignore list

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/7963/occurrence/464931288735

## Decision
Added to ignore list — this is an Android framework-internal NullPointerException in `android.widget.Magnifier.getPosition()` with zero application code in the stack trace. Known Android OS bug on certain devices when interacting with text selection handles.

## Root Cause
Android OS bug: `NullPointerException` when the system `Magnifier` widget tries to read `android.graphics.Rect.left` on a null reference during text selection handle interaction. The entire stack trace is Android framework code (`android.widget.Editor`, `android.view.View`, etc.) — no Liftosaur code involved.

## Test plan
- [ ] Verify build passes
- [ ] Verify unit tests pass
- [ ] Confirm the ignore string matches the error message pattern