### PR TITLE
fix-rollbar (6165/465003034148): ignore SyntaxError from old browsers

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -48,6 +48,7 @@ export const exceptionIgnores = [
   "_AutofillCallbackHandler",
   "Incorrect locale information provided",
   "chrome-extension://",
+  "Unexpected token .",
 ];
 
 export async function RollbarUtils_load(item: string | number, token: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Added `"Unexpected token ."` to the Rollbar exception ignore list in `src/utils/rollbar.ts`

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6165/occurrence/465003034148

## Decision
Added to ignore list. This error is a `SyntaxError: Unexpected token .` with no stack trace pointing to our code. It comes from Chrome 91 on Android 11 (V2055A device) — a very old, unsupported browser that cannot parse modern JavaScript syntax (likely optional chaining `?.`). No user state or actions were captured, meaning the error occurs before the app even loads. This is not actionable.

## Root Cause
Ancient browser (Chrome 91, released June 2021) attempting to parse modern JavaScript syntax it doesn't support. The error happens at the JS parsing level before any application code executes.

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] Unit tests pass (825 passing)
- [x] Playwright E2E: all failures are `Connection refused` (dev server not running) — unrelated to this change