### PR TITLE
fix-rollbar (6087/464999695211): Skip white screen detection for headless browsers

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -92,7 +92,7 @@ main();
 
 setTimeout(() => {
   const appEl = document.getElementById("app");
-  if (appEl && appEl.childElementCount === 0) {
+  if (appEl && appEl.childElementCount === 0 && !/HeadlessChrome/i.test(navigator.userAgent)) {
     Rollbar.error("White screen detected - app failed to render after 10s");
   }
 }, 10000);


### PR DESCRIPTION
## Summary
- Skip white screen detection for HeadlessChrome user agents to avoid false positives from bots/crawlers

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/6087/occurrence/464999695211

## Decision
This error was triggered by a HeadlessChrome/130.0.6723.31 bot visiting the app. The white screen detection fires after 10s, but headless browsers don't render the app — they're bots or automated tools, not real users. Rather than adding the entire "White screen detected" message to the ignore list (which would suppress real user white screens), we skip the detection for headless browsers specifically.

## Root Cause
The white screen detection in `src/index.tsx` fires a `Rollbar.error()` after 10s if the app container has no children. HeadlessChrome bots hit the production URL but don't execute the app properly, causing the check to trigger. There's no person, no exception data, and the only telemetry is a ServiceWorker failure and a Google Analytics request.

## Test plan
- [ ] Verify white screen detection still fires for real browsers (user agent without "HeadlessChrome")
- [ ] Verify HeadlessChrome user agents no longer trigger the white screen error