### PR TITLE
fix-rollbar (7610/464998512971): Fix HealthPermissionsRationaleActivity crash due to action bar theme conflict

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -7,6 +7,6 @@
         <item name="enforceNavigationBarContrast">false</item>
     </style>
 
-    <style name="AppCompatTheme" parent="Theme.AppCompat.Light.DarkActionBar" />
+    <style name="AppCompatTheme" parent="Theme.AppCompat.Light.NoActionBar" />
 
 </resources>


### PR DESCRIPTION
## Summary
- Fixed `IllegalStateException` crash in `HealthPermissionsRationaleActivity` on Android
- Changed `AppCompatTheme` parent from `Theme.AppCompat.Light.DarkActionBar` to `Theme.AppCompat.Light.NoActionBar`

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/7610/occurrence/464998512971

## Decision
Fixed — this is a real crash affecting users who open the Health Connect permissions rationale screen on Android.

## Root Cause
The `AppCompatTheme` style used `Theme.AppCompat.Light.DarkActionBar` as its parent, which provides a window-decor action bar. However, `HealthPermissionsRationaleActivity.onCreate()` also calls `setSupportActionBar(toolbar)` with a `Toolbar` widget from the layout. Android throws `IllegalStateException` because you cannot set a support action bar when the theme already supplies one via the window decor. The fix is to use `NoActionBar` as the parent theme so the custom `Toolbar` widget is used instead.

## Test plan
- [ ] Build Android APK and launch the Health Connect permissions rationale screen
- [ ] Verify the toolbar displays correctly with back navigation and title