### PR TITLE
fix-rollbar (7981/465067715430): ignore IndexedDB connection closing error

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -48,6 +48,7 @@ export const exceptionIgnores = [
   "_AutofillCallbackHandler",
   "Incorrect locale information provided",
   "chrome-extension://",
+  "The database connection is closing",
 ];
 
 export async function RollbarUtils_load(item: string | number, token: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Added `"The database connection is closing"` to the Rollbar exception ignore list in `src/utils/rollbar.ts`

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/7981/occurrence/465067715430

## Decision
Added to ignore list. This is a transient IndexedDB race condition caused by concurrent `indexedDB.open()` calls during page initialization. The `withTransaction` wrapper already catches and handles this error gracefully (returns `undefined`), so it doesn't affect user experience. A proper fix would require connection pooling, which is disproportionate to the impact.

## Root Cause
`IndexedDBUtils_initializeForSafari()` opens and immediately closes an IndexedDB connection. If another concurrent call to `IndexedDBUtils_initialize()` happens (e.g., `DeviceId_get()` on the `/p/` program page), the browser may return a connection that is already closing, causing `db.transaction()` to throw `InvalidStateError: The database connection is closing`.

## Test plan
- [ ] Verify the error message `"The database connection is closing"` matches the Rollbar exception
- [ ] Confirm existing unit tests pass (825 passing)
- [ ] Confirm build succeeds