### PR TITLE
fix-rollbar (7651/465059372158): ignore React Native Fabric addViewAt error

### DIFF
--- a/src/utils/rollbar.ts
+++ b/src/utils/rollbar.ts
@@ -48,6 +48,7 @@ export const exceptionIgnores = [
   "_AutofillCallbackHandler",
   "Incorrect locale information provided",
   "chrome-extension://",
+  "addViewAt: failed to insert view",
 ];
 
 export async function RollbarUtils_load(item: string | number, token: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Added `addViewAt: failed to insert view` to the Rollbar exception ignore list

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/7651/occurrence/465059372158

## Decision
Added to ignore list. This is a React Native Fabric internal error (`java.lang.IllegalStateException` in `SurfaceMountingManager.addViewAt`) caused by the native view tree getting into an inconsistent state. The entire stack trace is within React Native's Fabric rendering engine and Android's ViewGroup — zero application code is involved. This cannot be fixed at the application level.

## Root Cause
React Native Fabric's `SurfaceMountingManager` attempts to add a child view that already has a parent (`The specified child already has a parent. You must call removeView() on the child's parent first`). This is a known race condition in React Native's native view mounting pipeline during rapid UI updates. Occurred on Android 16 (Samsung Galaxy S24+).

## Test plan
- [x] Build succeeds
- [x] Lint passes
- [x] Unit tests pass (825 passing)
- [x] Playwright failures are all pre-existing (dev server not running in CI)