### PR TITLE
fix-rollbar (7391/465054657551): crash when Day appears before Week in full-text editor

### DIFF
--- a/src/pages/planner/plannerExerciseEvaluatorText.ts
+++ b/src/pages/planner/plannerExerciseEvaluatorText.ts
@@ -128,6 +128,9 @@ export class PlannerExerciseEvaluatorText {
     } else if (expr.type.name === PlannerNodeName.Day) {
       const dayName = this.getValue(expr).replace(/^#+/, "").trim();
       const description = this.getWeekDayDescriptionAndFillLastDay();
+      if (this.weeks.length === 0) {
+        this.weeks.push({ name: "Week 1", days: [] });
+      }
       this.weeks[this.weeks.length - 1].days.push({ name: dayName, exercises: [], description });
       this.ongoingLines = [];
     } else if (expr.type.name === PlannerNodeName.EmptyExpression) {

--- a/test/planner.test.ts
+++ b/test/planner.test.ts
@@ -2183,4 +2183,15 @@ customLogic[1-3] / used: none / 2x5-30 / 5lb / warmup: none / update: custom() {
       expect(record.entries[0].sets.length).to.equal(2);
     });
   });
+
+  it("does not crash when PlannerProgram_evaluateText encounters a Day before any Week", () => {
+    const programText = `## Day 1
+Squat / 3x5 100lb
+`;
+    const weeks = PlannerProgram_evaluateText(programText);
+    expect(weeks.length).to.equal(1);
+    expect(weeks[0].name).to.equal("Week 1");
+    expect(weeks[0].days.length).to.equal(1);
+    expect(weeks[0].days[0].name).to.equal("Day 1");
+  });
 });


### PR DESCRIPTION
## Summary
- Fix crash in `PlannerExerciseEvaluatorText.evaluateLine` when a `## Day` line appears before any `# Week` line in the full-text program editor
- Add guard to create a default "Week 1" when encountering a Day node before any Week has been created, matching the pattern used in `PlannerExerciseEvaluator`
- Add unit test to verify the fix

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/7391/occurrence/465054657551

## Decision
Fixed because this is a crash in our code that affects the normal user flow of editing program text. It occurs when a user temporarily deletes or edits the `# Week` header while editing in the full-text editor, causing the parser to encounter a `## Day` node before any week is created.

## Root Cause
`PlannerExerciseEvaluatorText.evaluateLine()` accesses `this.weeks[this.weeks.length - 1].days.push(...)` when processing a Day node, but does not check if `this.weeks` is empty. When the user edits program text such that a `## Day` line appears before any `# Week` line (a transient state during editing), `this.weeks[-1]` is `undefined` and `.days` throws `TypeError: Cannot read property 'days' of undefined`. The sister class `PlannerExerciseEvaluator` already had this guard (throwing a user-friendly error at line 913-914), but `PlannerExerciseEvaluatorText` did not.

## Test plan
- [ ] Unit test added: "does not crash when PlannerProgram_evaluateText encounters a Day before any Week"
- [ ] All 826 unit tests pass
- [ ] Build and lint pass