### PR TITLE
fix-rollbar (4783/465148540610): guard against null PopStateEvent.state in rep max calculator

### DIFF
--- a/src/pages/repmax/repMaxContent.tsx
+++ b/src/pages/repmax/repMaxContent.tsx
@@ -24,7 +24,7 @@ export function RepMaxContent(props: IRepMaxContentProps): JSX.Element {
 
   useEffect(() => {
     const onPopState = (e: PopStateEvent): void => {
-      if (e.state.reps) {
+      if (e.state?.reps) {
         setReps(e.state.reps);
       }
     };


### PR DESCRIPTION
## Summary
- Add optional chaining (`?.`) when accessing `e.state.reps` in the `popstate` event handler in `RepMaxContent`
- `PopStateEvent.state` can be `null` when navigating to a history entry created by normal navigation (not `pushState`/`replaceState`), causing a TypeError

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/4783/occurrence/465148540610

## Decision
Fixed because this is a legitimate bug in our code on a public-facing page (rep max calculator). The error affects normal user flows — users hitting browser back/forward can trigger this crash.

## Root Cause
The `popstate` event handler in `RepMaxContent` accesses `e.state.reps` without guarding against `e.state` being `null`. The `PopStateEvent.state` property is `null` for history entries not created via `pushState`/`replaceState` (e.g., the initial page load entry). When a user navigates back to such an entry, the handler crashes with `TypeError: null is not an object (evaluating 'e.state.reps')`.

## Test plan
- [ ] Navigate to any rep max calculator page (e.g. `/ten-rep-max-calculator`)
- [ ] Use browser back/forward buttons — should not crash
- [ ] Change reps input and verify URL updates correctly
- [ ] Use back button to navigate between rep max states — reps should restore from history state