### PR TITLE
fix-rollbar (7996/465146160601): skip malformed args in PlannerStateVars_fromArgs

### DIFF
--- a/src/pages/planner/models/plannerStateVars.ts
+++ b/src/pages/planner/models/plannerStateVars.ts
@@ -11,8 +11,11 @@ export function PlannerStateVars_fromArgs(
   for (const value of fnArgs) {
     // eslint-disable-next-line prefer-const
     let [fnArgKey, fnArgValStr] = value.split(":").map((v) => v.trim());
-    if (onError && (!fnArgKey || !fnArgValStr)) {
-      onError(`Invalid argument ${value}`);
+    if (!fnArgKey || !fnArgValStr) {
+      if (onError) {
+        onError(`Invalid argument ${value}`);
+      }
+      continue;
     }
     if (fnArgKey.endsWith("+")) {
       fnArgKey = fnArgKey.replace("+", "");

--- a/test/plannerStateVars.test.ts
+++ b/test/plannerStateVars.test.ts
@@ -1,0 +1,27 @@
+import "mocha";
+import { expect } from "chai";
+import { PlannerStateVars_fromArgs } from "../src/pages/planner/models/plannerStateVars";
+
+describe("PlannerStateVars_fromArgs", () => {
+  it("parses valid key:value args", () => {
+    const result = PlannerStateVars_fromArgs(["weight: 100lb", "reps: 5"]);
+    expect(result.state.weight).to.deep.equal({ value: 100, unit: "lb" });
+    expect(result.state.reps).to.equal(5);
+  });
+
+  it("does not crash on args missing a colon", () => {
+    const result = PlannerStateVars_fromArgs(["incomplete"]);
+    expect(result.state).to.deep.equal({});
+  });
+
+  it("does not crash on empty string args", () => {
+    const result = PlannerStateVars_fromArgs([""]);
+    expect(result.state).to.deep.equal({});
+  });
+
+  it("skips invalid args and parses valid ones", () => {
+    const result = PlannerStateVars_fromArgs(["bad", "good: 10"]);
+    expect(result.state.good).to.equal(10);
+    expect(Object.keys(result.state)).to.have.lengthOf(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix TypeError crash in `PlannerStateVars_fromArgs` when a function argument string doesn't contain a `:` separator
- The `value.split(":")` produces a single-element array, leaving `fnArgValStr` as `undefined`, which then crashes on `.match(/(lb|kg)/)`
- The existing guard on line 14 only reported the error when `onError` was provided, but the autocomplete code path in `liftoscriptCodemirror.ts` calls without it
- Now we `continue` past malformed arguments regardless of whether `onError` is set
- Added unit tests for `PlannerStateVars_fromArgs` covering the edge cases

## Rollbar
https://app.rollbar.com/a/astashov/fix/item/liftosaur/7996/occurrence/465146160601

## Decision
Fixed — this is a real bug in our code that crashes the CodeMirror autocomplete while users are mid-typing function arguments in the Liftoscript editor.

## Root Cause
`PlannerStateVars_fromArgs` splits each argument string on `:` to get `[key, value]`. When the user is still typing and the argument doesn't yet contain a `:`, `fnArgValStr` is `undefined`. The guard at line 14 only called `onError` (and didn't `continue`) when an `onError` callback was provided. The autocomplete path calls without `onError`, so execution fell through to `fnArgValStr.match(...)` which threw.

## Test plan
- [ ] Unit tests added and passing for `PlannerStateVars_fromArgs` with missing colon, empty string, and mixed valid/invalid args
- [ ] All 830 existing unit tests pass
- [ ] Build succeeds
- [ ] Lint passes