### PR TITLE
Worked example: minimize plate changes across workout sets (#199)

### DIFF
--- a/src/components/help/helpWorkout.tsx
+++ b/src/components/help/helpWorkout.tsx
@@ -24,8 +24,9 @@ export function HelpWorkout(): JSX.Element {
         <Text className="text-sm font-bold">185lb - 45/25</Text> means that to get{" "}
         <Text className="text-sm font-bold">185lb</Text> you need to put one{" "}
         <Text className="text-sm font-bold">45lb</Text> and one <Text className="text-sm font-bold">25lb</Text> plate on
-        each side of the bar. By tapping on the weights there you can change them for that workout. It won't change the
-        weight in the program though, only for that workout.
+        each side of the bar. Plates are listed from the bar outward. Following the sets in order can reduce plate
+        changes; if you skip around, load the complete stack shown. By tapping on the weights there you can change them
+        for that workout. It won't change the weight in the program though, only for that workout.
       </Text>
       <View className="flex-row flex-wrap items-center pb-2">
         <Text className="text-sm">

--- a/src/components/workoutExerciseAllSets.tsx
+++ b/src/components/workoutExerciseAllSets.tsx
@@ -33,6 +33,7 @@ import { memo, useCallback, useMemo } from "react";
 import { usePerfRenderCount } from "../utils/usePerfRenderCount";
 import { useTrackClick } from "../utils/clickTracking";
 import { useRem } from "../utils/useRem";
+import { IWeightPlatesResult, Weight_calculatePlatesForSets } from "../models/weight";
 
 interface IWorkoutExerciseAllSets {
   day: number;
@@ -55,6 +56,7 @@ interface IWorkoutExerciseAllSets {
   otherStates?: IByExercise<IProgramState>;
   settings: ISettings;
   dispatch: IDispatch;
+  plateResults?: ReadonlyMap<string, IWeightPlatesResult>;
 }
 
 function getTargetColumnLabel(targetType: ITargetType): string {
@@ -83,6 +85,12 @@ function WorkoutExerciseAllSetsInner(props: IWorkoutExerciseAllSets): JSX.Elemen
     warmupSets[0]?.weight?.unit ??
     Equipment_getUnitOrDefaultForExerciseType(props.settings, props.exerciseType);
   const targetLabel = getTargetColumnLabel(props.settings.workoutSettings.targetType);
+  const plateResults = useMemo(() => {
+    if (props.plateResults != null) {
+      return props.plateResults;
+    }
+    return Weight_calculatePlatesForSets([...warmupSets, ...sets], props.settings, props.exerciseType);
+  }, [props.plateResults, warmupSets, sets, props.settings, props.exerciseType]);
   const lbEntry = useMemo(() => lb<IHistoryRecord>().p("entries").i(props.entryIndex), [props.entryIndex]);
   const isUnilateral = Exercise_getIsUnilateral(props.exerciseType, props.settings);
   const remValue = useRem();
@@ -205,6 +213,7 @@ function WorkoutExerciseAllSetsInner(props: IWorkoutExerciseAllSets): JSX.Elemen
             lbSets={props.lbWarmupSets}
             lbSet={lbWarmupSetByIndex[i]}
             set={set}
+            plateResult={plateResults.get(set.id)}
             entryIndex={props.entryIndex}
             isNext={nextSetIndex === i}
             setIndex={i}
@@ -231,6 +240,7 @@ function WorkoutExerciseAllSetsInner(props: IWorkoutExerciseAllSets): JSX.Elemen
             lbSets={props.lbSets}
             lbSet={lbSetByIndex[i]}
             set={set}
+            plateResult={plateResults.get(set.id)}
             entryIndex={props.entryIndex}
             setIndex={i}
             columnWidths={columnWidths}

--- a/src/components/workoutExerciseCard.tsx
+++ b/src/components/workoutExerciseCard.tsx
@@ -16,7 +16,7 @@ import { IconArrowRight } from "./icons/iconArrowRight";
 import { ActionSheet_show } from "../utils/actionSheet";
 import { LinkButton } from "./linkButton";
 import { ProgramExercise_doesUse1RM } from "../models/programExercise";
-import { Weight_print, Weight_build } from "../models/weight";
+import { Weight_print, Weight_build, Weight_calculatePlatesForSets } from "../models/weight";
 import { WorkoutPlatesCalculator } from "./workoutPlatesCalculator";
 import { Markdown } from "./markdown";
 import { CollectionUtils_removeAt } from "../utils/collection";
@@ -102,6 +102,10 @@ function WorkoutExerciseCardInner(props: IWorkoutExerciseCardProps): JSX.Element
   const nextSet = useMemo(
     () => [...props.entry.warmupSets, ...props.entry.sets].filter((s) => !s.isCompleted)[0],
     [props.entry.warmupSets, props.entry.sets]
+  );
+  const plateResults = useMemo(
+    () => Weight_calculatePlatesForSets([...props.entry.warmupSets, ...props.entry.sets], settings, exerciseType),
+    [props.entry.warmupSets, props.entry.sets, settings, exerciseType]
   );
   const lbSets = useMemo(() => lb<IHistoryRecord>().p("entries").i(props.entryIndex).p("sets"), [props.entryIndex]);
   const lbWarmupSets = useMemo(
@@ -494,6 +498,7 @@ function WorkoutExerciseCardInner(props: IWorkoutExerciseCardProps): JSX.Element
             <WorkoutPlatesCalculator
               entry={props.entry}
               weight={nextSet.completedWeight ?? nextSet.weight ?? Weight_build(0, props.settings.units)}
+              plateResult={plateResults.get(nextSet.id)}
               subscription={props.subscription}
               settings={props.settings}
               dispatch={props.dispatch}
@@ -521,6 +526,7 @@ function WorkoutExerciseCardInner(props: IWorkoutExerciseCardProps): JSX.Element
           lbWarmupSets={lbWarmupSets}
           exerciseType={exerciseType}
           entry={props.entry}
+          plateResults={plateResults}
           settings={props.settings}
           dispatch={props.dispatch}
           subscription={props.subscription}

--- a/src/components/workoutExerciseSet.tsx
+++ b/src/components/workoutExerciseSet.tsx
@@ -43,9 +43,10 @@ import {
   Weight_rpeMultiplier,
   Weight_multiply,
   Weight_calculatePlates,
-  Weight_formatOneSide,
   Weight_isPct,
   Weight_getOneRepMax,
+  IWeightPlatesResult,
+  Weight_formatOneSideOrdered,
 } from "../models/weight";
 import { Exercise_getIsUnilateral, Exercise_onerm } from "../models/exercise";
 import { FocusedInputFlush_flush } from "../utils/focusedInputFlush";
@@ -110,6 +111,7 @@ interface IWorkoutExerciseSet {
   columnWidths: ISetColumnWidths;
   settings: ISettings;
   dispatch: IDispatch;
+  plateResult?: IWeightPlatesResult;
 }
 
 function WorkoutExerciseSetInner(props: IWorkoutExerciseSet): JSX.Element {
@@ -304,6 +306,7 @@ function WorkoutExerciseSetInner(props: IWorkoutExerciseSet): JSX.Element {
                 settings={props.settings}
                 exerciseType={props.exerciseType}
                 underlineRounded={isRoundedWeight}
+                plateResult={props.plateResult}
               />
             </Pressable>
 
@@ -703,6 +706,7 @@ interface IWorkoutExerciseSetTargetFieldProps {
   settings: ISettings;
   exerciseType: IExerciseType;
   underlineRounded?: boolean;
+  plateResult?: IWeightPlatesResult;
 }
 
 function WorkoutExerciseSetTargetField(props: IWorkoutExerciseSetTargetFieldProps): JSX.Element {
@@ -717,7 +721,12 @@ function WorkoutExerciseSetTargetField(props: IWorkoutExerciseSetTargetFieldProp
     }
     case "platescalculator": {
       return (
-        <WorkoutExercisePlatesCalculator set={props.set} settings={props.settings} exerciseType={props.exerciseType} />
+        <WorkoutExercisePlatesCalculator
+          set={props.set}
+          settings={props.settings}
+          exerciseType={props.exerciseType}
+          plateResult={props.plateResult}
+        />
       );
     }
     case "e1rm": {
@@ -731,6 +740,7 @@ interface IWorkoutExercisePlatesCalculatorProps {
   set: ISet;
   settings: ISettings;
   exerciseType: IExerciseType;
+  plateResult?: IWeightPlatesResult;
 }
 
 function WorkoutExercisePlatesCalculator(props: IWorkoutExercisePlatesCalculatorProps): JSX.Element {
@@ -743,13 +753,11 @@ function WorkoutExercisePlatesCalculator(props: IWorkoutExercisePlatesCalculator
     );
   }
 
-  const { plates, totalWeight: weight } = Weight_calculatePlates(
-    props.set.completedWeight ?? setWeight,
-    props.settings,
-    setWeight.unit,
-    props.exerciseType
-  );
-  const formattedPlates = plates.length > 0 ? Weight_formatOneSide(props.settings, plates, props.exerciseType) : "None";
+  const { plates, totalWeight: weight } =
+    props.plateResult ??
+    Weight_calculatePlates(props.set.completedWeight ?? setWeight, props.settings, setWeight.unit, props.exerciseType);
+  const formattedPlates =
+    plates.length > 0 ? Weight_formatOneSideOrdered(props.settings, plates, props.exerciseType) : "None";
   return (
     <Text
       className={`text-sm font-semibold ${Weight_eq(weight, props.set.completedWeight ?? setWeight) ? "text-text-primary" : "text-text-error"}`}

--- a/src/components/workoutPlatesCalculator.tsx
+++ b/src/components/workoutPlatesCalculator.tsx
@@ -4,7 +4,7 @@ import { Text } from "./primitives/text";
 import { Path } from "./primitives/svg";
 import { IconSvg } from "./icons/iconSvg";
 import { IHistoryEntry, ISettings, ISubscription, IWeight } from "../types";
-import { Weight_calculatePlates, Weight_eq, Weight_formatOneSide } from "../models/weight";
+import { IWeightPlatesResult, Weight_calculatePlates, Weight_eq, Weight_formatOneSideOrdered } from "../models/weight";
 import { Subscriptions_hasSubscription } from "../utils/subscriptions";
 import { Tailwind_semantic } from "../utils/tailwindConfig";
 import { WorkoutExerciseUtils_getBgColor100 } from "../utils/workoutExerciseUtils";
@@ -18,6 +18,7 @@ interface IWorkoutPlatesCalculatorProps {
   subscription: ISubscription;
   settings: ISettings;
   dispatch: IDispatch;
+  plateResult?: IWeightPlatesResult;
 }
 
 function BarbellIcon(): JSX.Element {
@@ -36,12 +37,8 @@ function BarbellIcon(): JSX.Element {
 
 function WorkoutPlatesCalculatorInner(props: IWorkoutPlatesCalculatorProps): JSX.Element {
   const isSubscribed = Subscriptions_hasSubscription(props.subscription);
-  const { plates, totalWeight: weight } = Weight_calculatePlates(
-    props.weight,
-    props.settings,
-    props.weight.unit,
-    props.entry.exercise
-  );
+  const { plates, totalWeight: weight } =
+    props.plateResult ?? Weight_calculatePlates(props.weight, props.settings, props.weight.unit, props.entry.exercise);
   const isPlatesMatch = Weight_eq(weight, props.weight);
   return (
     <View className="self-start my-1">
@@ -60,7 +57,7 @@ function WorkoutPlatesCalculatorInner(props: IWorkoutPlatesCalculatorProps): JSX
                 data-testid="plates-list"
                 testID="plates-list"
               >
-                {plates.length > 0 ? Weight_formatOneSide(props.settings, plates, props.entry.exercise) : "None"}
+                {plates.length > 0 ? Weight_formatOneSideOrdered(props.settings, plates, props.entry.exercise) : "None"}
               </Text>
             </Text>
           ) : (

--- a/src/models/plateOptimizer.ts
+++ b/src/models/plateOptimizer.ts
@@ -1,0 +1,539 @@
+/**
+ * Finds plate stacks for an entire exercise, rather than solving each set independently.
+ *
+ * This module deliberately knows nothing about exercises, equipment settings, or pounds and kilograms. Its caller
+ * converts weights to exact integers and assigns each plate type a call-local array index. A stack is an array of those
+ * indexes ordered from the bar outward. Thus, two stacks with the same plates in a different order are different: only
+ * their common inner prefix can remain on the bar between sets.
+ *
+ * `initialStacks` is the reliability boundary of the abstraction. The caller provides one known-good stack per target;
+ * this module validates those stacks and uses them as a complete fallback plan. Search limits can therefore control
+ * CPU and memory without creating a failure mode for the workout: the result is always at least the supplied plan.
+ */
+export interface IPlateOptimizerLimits {
+  /** Bounds auxiliary work before graph search starts. */
+  maxDpCells: number;
+  maxLowerBoundIterations: number;
+  /** Bounds the graph search itself. Reaching any bound returns the best complete plan found so far. */
+  maxExpandedStates: number;
+  maxStoredStates: number;
+  maxQueueSize: number;
+}
+
+export interface IPlateOptimizerInput {
+  /** Positive integer weights. The array position is the plate's identity for this call only. */
+  plateWeights: number[];
+  /** Maximum plates of each type available on the one side being optimized. */
+  maxPlateCounts: number[];
+  /** Required one-sided plate loads, in workout order and in the same integer units as plateWeights. */
+  targets: number[];
+  /** A feasible complete stack for every target; also the fallback returned if bounded search cannot improve it. */
+  initialStacks: number[][];
+  limits?: Partial<IPlateOptimizerLimits>;
+}
+
+export type IPlateOptimizerOperation = { type: "push"; plateIndex: number } | { type: "pop"; plateIndex: number };
+
+export interface IPlateOptimizerResult {
+  /** Complete stacks at each target, ordered from the bar outward. */
+  stacks: number[][];
+  /** A replayable path from an empty bar through every target and back to empty. */
+  operations: IPlateOptimizerOperation[];
+  actionCount: number;
+  /** False means a resource bound stopped search; it does not mean that the returned plan is incomplete or invalid. */
+  searchCompleted: boolean;
+  expandedStates: number;
+}
+
+// These are responsiveness limits, not parts of the physical plate model. Inventory makes the model finite; the limits
+// prevent an unusual custom inventory or workout from monopolizing the UI thread.
+const defaultLimits: IPlateOptimizerLimits = {
+  maxDpCells: 200000,
+  maxLowerBoundIterations: 1000000,
+  maxExpandedStates: 50000,
+  maxStoredStates: 100000,
+  maxQueueSize: 100000,
+};
+
+interface ISearchState {
+  key: string;
+  // A state has satisfied targets [0, targetIndex). The stack is the other half of its identity.
+  targetIndex: number;
+  stack: number[];
+  // The remaining fields are caches derived from stack, except cost (A*'s g) and estimate (g + h).
+  counts: number[];
+  weight: number;
+  cost: number;
+  estimate: number;
+  order: number;
+}
+
+interface IParent {
+  key: string;
+  operation?: IPlateOptimizerOperation;
+}
+
+class MinHeap {
+  // A private heap keeps the specialized search self-contained. It supports duplicate entries because A* may discover
+  // a cheaper route to a state after that state has already been queued.
+  private readonly values: ISearchState[] = [];
+
+  public get size(): number {
+    return this.values.length;
+  }
+
+  public push(value: ISearchState): void {
+    this.values.push(value);
+    let index = this.values.length - 1;
+    while (index > 0) {
+      const parentIndex = Math.floor((index - 1) / 2);
+      if (compareSearchStates(this.values[parentIndex], value) <= 0) {
+        break;
+      }
+      this.values[index] = this.values[parentIndex];
+      index = parentIndex;
+    }
+    this.values[index] = value;
+  }
+
+  public pop(): ISearchState | undefined {
+    const first = this.values[0];
+    const last = this.values.pop();
+    if (first == null || last == null || this.values.length === 0) {
+      return first;
+    }
+
+    let index = 0;
+    while (true) {
+      const left = index * 2 + 1;
+      const right = left + 1;
+      if (left >= this.values.length) {
+        break;
+      }
+      let child = left;
+      if (right < this.values.length && compareSearchStates(this.values[right], this.values[left]) < 0) {
+        child = right;
+      }
+      if (compareSearchStates(last, this.values[child]) <= 0) {
+        break;
+      }
+      this.values[index] = this.values[child];
+      index = child;
+    }
+    this.values[index] = last;
+    return first;
+  }
+}
+
+function compareSearchStates(a: ISearchState, b: ISearchState): number {
+  if (a.estimate !== b.estimate) {
+    return a.estimate - b.estimate;
+  }
+  // For equal lower bounds, prefer a path that has already done more work. This tends to reach a complete incumbent
+  // sooner, which tightens branch-and-bound pruning, but does not affect which plans are legal.
+  if (a.cost !== b.cost) {
+    return b.cost - a.cost;
+  }
+  return a.order - b.order;
+}
+
+function stateKey(targetIndex: number, stack: number[]): string {
+  // Weight or plate counts are insufficient identities: future removal cost depends on the full plate order.
+  return `${targetIndex}|${stack.join(",")}`;
+}
+
+function commonPrefixLength(a: number[], b: number[]): number {
+  const length = Math.min(a.length, b.length);
+  let index = 0;
+  while (index < length && a[index] === b[index]) {
+    index += 1;
+  }
+  return index;
+}
+
+function buildOperations(stacks: number[][]): IPlateOptimizerOperation[] {
+  // The shortest route between two fixed stacks removes the old suffix after their common prefix, then adds the new
+  // suffix. Appending [] includes the required final unload in the incumbent's cost.
+  const operations: IPlateOptimizerOperation[] = [];
+  let current: number[] = [];
+  for (const stack of [...stacks, []]) {
+    const retained = commonPrefixLength(current, stack);
+    for (let index = current.length - 1; index >= retained; index -= 1) {
+      operations.push({ type: "pop", plateIndex: current[index] });
+    }
+    for (let index = retained; index < stack.length; index += 1) {
+      operations.push({ type: "push", plateIndex: stack[index] });
+    }
+    current = stack;
+  }
+  return operations;
+}
+
+function validateInput(input: IPlateOptimizerInput): void {
+  // There is no separate reachability calculation here: validating a supplied stack for every target proves
+  // reachability and avoids duplicating the application's existing plate-selection logic.
+  if (input.plateWeights.length !== input.maxPlateCounts.length) {
+    throw new Error("Plate weights and inventory must have the same length");
+  }
+  if (input.targets.length !== input.initialStacks.length) {
+    throw new Error("Every target must have an initial stack");
+  }
+  for (const weight of input.plateWeights) {
+    if (!Number.isSafeInteger(weight) || weight <= 0) {
+      throw new Error("Plate weights must be positive safe integers");
+    }
+  }
+  for (const count of input.maxPlateCounts) {
+    if (!Number.isSafeInteger(count) || count < 0) {
+      throw new Error("Plate inventory must contain non-negative safe integers");
+    }
+  }
+  for (let targetIndex = 0; targetIndex < input.targets.length; targetIndex += 1) {
+    const target = input.targets[targetIndex];
+    if (!Number.isSafeInteger(target) || target < 0) {
+      throw new Error("Targets must be non-negative safe integers");
+    }
+    const counts = new Array(input.plateWeights.length).fill(0);
+    let weight = 0;
+    for (const plateIndex of input.initialStacks[targetIndex]) {
+      if (!Number.isSafeInteger(plateIndex) || plateIndex < 0 || plateIndex >= input.plateWeights.length) {
+        throw new Error("An initial stack refers to an unknown plate");
+      }
+      counts[plateIndex] += 1;
+      if (counts[plateIndex] > input.maxPlateCounts[plateIndex]) {
+        throw new Error("An initial stack exceeds plate inventory");
+      }
+      weight += input.plateWeights[plateIndex];
+    }
+    if (weight !== target) {
+      throw new Error("An initial stack does not match its target");
+    }
+  }
+}
+
+function minimumPlateCounts(maxTarget: number, plateWeights: number[]): number[] {
+  // This deliberately ignores inventory and ordering. The relaxed problem can only use fewer plates than the physical
+  // problem, so its answer is safe as an A* lower bound even when it is physically impossible.
+  const counts = new Array(maxTarget + 1).fill(Infinity);
+  counts[0] = 0;
+  for (let weight = 1; weight <= maxTarget; weight += 1) {
+    for (const plateWeight of plateWeights) {
+      if (plateWeight <= weight && counts[weight - plateWeight] !== Infinity) {
+        counts[weight] = Math.min(counts[weight], counts[weight - plateWeight] + 1);
+      }
+    }
+  }
+  return counts;
+}
+
+function transitionLowerBound(from: number, to: number, minimumCounts: number[]): number {
+  // Treat each possible retained weight as though both stacks could realize it with an identical prefix. Some cannot;
+  // that optimism is intentional, since overestimating here could make A* discard the best real plan.
+  let best = Infinity;
+  for (let retainedWeight = 0; retainedWeight <= Math.min(from, to); retainedWeight += 1) {
+    const removed = minimumCounts[from - retainedWeight];
+    const added = minimumCounts[to - retainedWeight];
+    if (removed !== Infinity && added !== Infinity) {
+      best = Math.min(best, removed + added);
+    }
+  }
+  return best;
+}
+
+function lowerBoundToNextTarget(
+  stack: number[],
+  target: number,
+  plateWeights: number[],
+  minimumCounts: number[]
+): number {
+  // Unlike future target pairs, the current stack is known. Examine its actual prefixes; for each one, count the pops
+  // needed to expose it and use the relaxed table for the minimum pushes needed afterward.
+  let best = Infinity;
+  let retainedWeight = 0;
+  for (let retained = 0; retained <= stack.length; retained += 1) {
+    if (retainedWeight <= target) {
+      const platesToAdd = minimumCounts[target - retainedWeight];
+      if (platesToAdd !== Infinity) {
+        best = Math.min(best, stack.length - retained + platesToAdd);
+      }
+    }
+    if (retained < stack.length) {
+      retainedWeight += plateWeights[stack[retained]];
+    }
+  }
+  return best;
+}
+
+function reconstruct(
+  goalKey: string,
+  parents: Map<string, IParent>,
+  states: Map<string, Pick<ISearchState, "targetIndex" | "stack">>,
+  targetCount: number
+): { stacks: number[][]; operations: IPlateOptimizerOperation[] } {
+  // Target-advance edges cost nothing and do not change the stack. The stack before such an edge is therefore the
+  // complete display stack for the target just satisfied, including repeated targets.
+  const keys: string[] = [];
+  let key: string | undefined = goalKey;
+  while (key != null) {
+    keys.push(key);
+    key = parents.get(key)?.key;
+  }
+  keys.reverse();
+
+  const stacks: number[][] = [];
+  const operations: IPlateOptimizerOperation[] = [];
+  for (let index = 1; index < keys.length; index += 1) {
+    const previous = states.get(keys[index - 1]);
+    const current = states.get(keys[index]);
+    if (previous == null || current == null) {
+      throw new Error("Could not reconstruct plate optimizer path");
+    }
+    const parent = parents.get(keys[index]);
+    if (parent?.operation != null) {
+      operations.push(parent.operation);
+    }
+    if (current.targetIndex > previous.targetIndex) {
+      stacks.push([...previous.stack]);
+    }
+  }
+  if (stacks.length !== targetCount) {
+    throw new Error("Plate optimizer path did not visit every target");
+  }
+  return { stacks, operations };
+}
+
+export function PlateOptimizer_optimize(input: IPlateOptimizerInput): IPlateOptimizerResult {
+  validateInput(input);
+  const limits = { ...defaultLimits, ...input.limits };
+  // Preserve the conventional plan unless search finds a strict improvement. Besides giving bounded search a safe
+  // answer, this avoids surprising plate order when optimization would save no actions.
+  const incumbentOperations = buildOperations(input.initialStacks);
+  let incumbentStacks = input.initialStacks.map((stack) => [...stack]);
+  let incumbent = incumbentOperations;
+  let incumbentCost = incumbent.length;
+
+  if (input.targets.length === 0) {
+    return { stacks: [], operations: [], actionCount: 0, searchCompleted: true, expandedStates: 0 };
+  }
+
+  const maxTarget = Math.max(...input.targets);
+  if (maxTarget + 1 > limits.maxDpCells) {
+    return {
+      stacks: incumbentStacks,
+      operations: incumbent,
+      actionCount: incumbentCost,
+      searchCompleted: false,
+      expandedStates: 0,
+    };
+  }
+
+  const minimumCounts = minimumPlateCounts(maxTarget, input.plateWeights);
+  // futureLowerBounds[k] covers transitions from target k onward plus unloading the final stack. The cost of reaching
+  // target k from the current stack is added separately by heuristic().
+  const futureLowerBounds = new Array(input.targets.length).fill(0);
+  let futureCost = minimumCounts[input.targets[input.targets.length - 1]];
+  let lowerBoundIterations = 0;
+  if (futureCost === Infinity) {
+    throw new Error("A target is not representable by the relaxed plate system");
+  }
+  futureLowerBounds[input.targets.length - 1] = futureCost;
+  for (let index = input.targets.length - 2; index >= 0; index -= 1) {
+    lowerBoundIterations += Math.min(input.targets[index], input.targets[index + 1]) + 1;
+    if (lowerBoundIterations > limits.maxLowerBoundIterations) {
+      return {
+        stacks: incumbentStacks,
+        operations: incumbent,
+        actionCount: incumbentCost,
+        searchCompleted: false,
+        expandedStates: 0,
+      };
+    }
+    const transition = transitionLowerBound(input.targets[index], input.targets[index + 1], minimumCounts);
+    if (transition === Infinity) {
+      throw new Error("A target transition is not representable by the relaxed plate system");
+    }
+    futureCost += transition;
+    futureLowerBounds[index] = futureCost;
+  }
+
+  function heuristic(targetIndex: number, stack: number[]): number {
+    if (targetIndex === input.targets.length) {
+      // Once every target has been recorded, pushing cannot help; each remaining plate must be popped exactly once.
+      return stack.length;
+    }
+    return (
+      lowerBoundToNextTarget(stack, input.targets[targetIndex], input.plateWeights, minimumCounts) +
+      futureLowerBounds[targetIndex]
+    );
+  }
+
+  const queue = new MinHeap();
+  // bestCosts implements dominance by exact state and permits reopening. Parents and states retain only the currently
+  // cheapest path to each key, which is enough to reconstruct a complete improved plan.
+  const bestCosts = new Map<string, number>();
+  const parents = new Map<string, IParent>();
+  const states = new Map<string, Pick<ISearchState, "targetIndex" | "stack">>();
+  const startStack: number[] = [];
+  const startKey = stateKey(0, startStack);
+  const startHeuristic = heuristic(0, startStack);
+  let insertionOrder = 0;
+  bestCosts.set(startKey, 0);
+  states.set(startKey, { targetIndex: 0, stack: startStack });
+  queue.push({
+    key: startKey,
+    targetIndex: 0,
+    stack: startStack,
+    counts: new Array(input.plateWeights.length).fill(0),
+    weight: 0,
+    cost: 0,
+    estimate: startHeuristic,
+    order: insertionOrder,
+  });
+
+  let expandedStates = 0;
+  let resourceLimitReached = false;
+  const plateIndexes = input.plateWeights
+    .map((_, index) => index)
+    .sort((a, b) => input.plateWeights[b] - input.plateWeights[a] || a - b);
+
+  function addSuccessor(
+    current: ISearchState,
+    targetIndex: number,
+    stack: number[],
+    counts: number[],
+    weight: number,
+    actionCost: number,
+    operation?: IPlateOptimizerOperation
+  ): void {
+    if (resourceLimitReached) {
+      return;
+    }
+    const cost = current.cost + actionCost;
+    const key = stateKey(targetIndex, stack);
+    const knownCost = bestCosts.get(key);
+    // Identical states have identical possible futures, so only their cheapest discovered prefix matters.
+    if (knownCost != null && knownCost <= cost) {
+      return;
+    }
+    const remaining = heuristic(targetIndex, stack);
+    // The heuristic is optimistic. If even that optimistic completion cannot strictly beat the incumbent, this branch
+    // cannot change the user-visible result.
+    if (cost + remaining >= incumbentCost) {
+      return;
+    }
+    if (knownCost == null && bestCosts.size >= limits.maxStoredStates) {
+      resourceLimitReached = true;
+      return;
+    }
+    if (queue.size >= limits.maxQueueSize) {
+      resourceLimitReached = true;
+      return;
+    }
+    bestCosts.set(key, cost);
+    parents.set(key, { key: current.key, operation });
+    states.set(key, { targetIndex, stack });
+    insertionOrder += 1;
+    queue.push({
+      key,
+      targetIndex,
+      stack,
+      counts,
+      weight,
+      cost,
+      estimate: cost + remaining,
+      order: insertionOrder,
+    });
+  }
+
+  while (queue.size > 0 && !resourceLimitReached) {
+    const current = queue.pop()!;
+    // Reopening leaves older, more expensive queue entries behind. Ignore them when they eventually reach the top.
+    if (bestCosts.get(current.key) !== current.cost) {
+      continue;
+    }
+    if (current.estimate >= incumbentCost) {
+      // The heap is ordered by estimate, so no unvisited state can now improve the incumbent.
+      break;
+    }
+    if (expandedStates >= limits.maxExpandedStates) {
+      resourceLimitReached = true;
+      break;
+    }
+    expandedStates += 1;
+
+    if (current.targetIndex === input.targets.length && current.stack.length === 0) {
+      // A goal removed from the heap is a complete, fully unloaded plan. Updating the incumbent makes all subsequent
+      // pruning stronger; the loop then proves that no cheaper frontier state remains.
+      const reconstructed = reconstruct(current.key, parents, states, input.targets.length);
+      incumbentStacks = reconstructed.stacks;
+      incumbent = reconstructed.operations;
+      incumbentCost = incumbent.length;
+      continue;
+    }
+
+    if (current.targetIndex < input.targets.length && current.weight === input.targets[current.targetIndex]) {
+      // Recording a completed set changes no plates. Taking this edge immediately is always safe and naturally handles
+      // repeated target weights.
+      addSuccessor(current, current.targetIndex + 1, current.stack, current.counts, current.weight, 0);
+      continue;
+    }
+
+    const nextTarget = current.targetIndex < input.targets.length ? input.targets[current.targetIndex] : undefined;
+    const shouldPushFirst = nextTarget != null && current.weight < nextTarget;
+
+    const addPop = (): void => {
+      if (current.stack.length === 0) {
+        return;
+      }
+      const plateIndex = current.stack[current.stack.length - 1];
+      const stack = current.stack.slice(0, -1);
+      const counts = [...current.counts];
+      counts[plateIndex] -= 1;
+      addSuccessor(current, current.targetIndex, stack, counts, current.weight - input.plateWeights[plateIndex], 1, {
+        type: "pop",
+        plateIndex,
+      });
+    };
+
+    const addPushes = (): void => {
+      if (nextTarget == null) {
+        return;
+      }
+      for (const plateIndex of plateIndexes) {
+        if (current.counts[plateIndex] >= input.maxPlateCounts[plateIndex]) {
+          continue;
+        }
+        const weight = current.weight + input.plateWeights[plateIndex];
+        // An optimal route to the next target first pops to a retained prefix, then pushes its new suffix. A push above
+        // the target would have to be popped before the set and can simply be omitted, so overshoot is never useful.
+        if (weight > nextTarget) {
+          continue;
+        }
+        const counts = [...current.counts];
+        counts[plateIndex] += 1;
+        addSuccessor(current, current.targetIndex, [...current.stack, plateIndex], counts, weight, 1, {
+          type: "push",
+          plateIndex,
+        });
+      }
+    };
+
+    if (shouldPushFirst) {
+      // Successor order affects how quickly a good incumbent is found, not the set of plans searched. Favor the action
+      // that moves toward the target; plateIndexes similarly tries larger plates first.
+      addPushes();
+      addPop();
+    } else {
+      addPop();
+      addPushes();
+    }
+  }
+
+  return {
+    stacks: incumbentStacks,
+    operations: incumbent,
+    actionCount: incumbentCost,
+    searchCompleted: !resourceLimitReached,
+    expandedStates,
+  };
+}

--- a/src/models/progress.ts
+++ b/src/models/progress.ts
@@ -27,7 +27,8 @@ import {
   Weight_convertToWeight,
   Weight_display,
   Weight_calculatePlates,
-  Weight_formatOneSide,
+  Weight_calculatePlatesForSets,
+  Weight_formatOneSideOrdered,
   Weight_rpePct,
   Weight_evaluateWeight,
   Weight_op,
@@ -398,8 +399,11 @@ export function Progress_scheduleTimerNotification(
         aSet.weight != null ? Weight_display(aSet.weight) : undefined,
       ]).join(", ");
       if (aSet.weight != null) {
-        const { plates } = Weight_calculatePlates(aSet.weight, settings, aSet.weight.unit, nextEntry.exercise);
-        const formattedPlates = plates.length > 0 ? Weight_formatOneSide(settings, plates, exercise) : "None";
+        const allSets = [...nextEntry.warmupSets, ...nextEntry.sets];
+        const { plates } =
+          Weight_calculatePlatesForSets(allSets, settings, nextEntry.exercise).get(aSet.id) ??
+          Weight_calculatePlates(aSet.weight, settings, aSet.weight.unit, nextEntry.exercise);
+        const formattedPlates = plates.length > 0 ? Weight_formatOneSideOrdered(settings, plates, exercise) : "None";
         bodyHeader = "Plates per side";
         body = formattedPlates;
       }

--- a/src/models/weight.ts
+++ b/src/models/weight.ts
@@ -1,6 +1,6 @@
 import { CollectionUtils_sort, CollectionUtils_compressArray } from "../utils/collection";
 
-import { IWeight, IUnit, ISettings, IPlate, IPercentage, IExerciseType } from "../types";
+import { IWeight, IUnit, ISettings, IPlate, IPercentage, IExerciseType, ISet } from "../types";
 import { n, MathUtils_roundTo005, MathUtils_round, MathUtils_roundFloat, MathUtils_roundTo000005 } from "../utils/math";
 import {
   Equipment_getUnitOrDefaultForExerciseType,
@@ -8,8 +8,18 @@ import {
   Equipment_smallestPlate,
 } from "./equipment";
 import { Exercise_get, Exercise_onerm, Exercise_defaultRounding } from "./exercise";
+import { PlateOptimizer_optimize } from "./plateOptimizer";
 
 const prebuiltWeights: Partial<Record<string, IWeight>> = {};
+const USE_OPTIMIZED_PLATE_CALCULATOR = true;
+// This is an optimizer eligibility guard, not a claimed physical sleeve limit. Larger stacks use the legacy answer.
+const MAX_OPTIMIZER_STACK_PLATES = 64;
+
+export interface IWeightPlatesResult {
+  plates: IPlate[];
+  platesWeight: IWeight;
+  totalWeight: IWeight;
+}
 
 export function Weight_display(weight: IWeight | IPercentage | number, withUnit: boolean = true): string {
   if (typeof weight === "number") {
@@ -292,6 +302,22 @@ export function Weight_formatOneSide(settings: ISettings, platesArr: IPlate[], e
   return CollectionUtils_compressArray(arr, 3).join("/");
 }
 
+export function Weight_formatOneSideOrdered(
+  settings: ISettings,
+  plates: IPlate[],
+  exerciseType: IExerciseType
+): string {
+  const multiplier = Equipment_getEquipmentDataForExerciseType(settings, exerciseType)?.multiplier ?? 1;
+  const values: number[] = [];
+  for (const plate of plates) {
+    const count = Math.floor(plate.num / multiplier);
+    for (let index = 0; index < count; index += 1) {
+      values.push(plate.weight.value);
+    }
+  }
+  return CollectionUtils_compressArray(values, 3).join("/");
+}
+
 export function Weight_roundTo005(weight: IWeight): IWeight {
   return Weight_build(MathUtils_roundTo005(weight.value), weight.unit);
 }
@@ -305,7 +331,7 @@ export function Weight_calculatePlates(
   settings: ISettings,
   units: IUnit,
   exerciseType: IExerciseType
-): { plates: IPlate[]; platesWeight: IWeight; totalWeight: IWeight } {
+): IWeightPlatesResult {
   const equipmentData = Equipment_getEquipmentDataForExerciseType(settings, exerciseType);
   if (equipmentData == null) {
     const rounding = Exercise_defaultRounding(exerciseType, settings);
@@ -348,6 +374,167 @@ export function Weight_calculatePlates(
   );
   const thePlatesWeight = inverted ? Weight_invert(total) : total;
   return { plates, platesWeight: thePlatesWeight, totalWeight };
+}
+
+function Weight_toMilliUnits(value: number): number | undefined {
+  // One integer step is a millipound for lb equipment and a gram for kg equipment. Units are never mixed here.
+  const scaled = value * 1000;
+  const rounded = Math.round(scaled);
+  if (!Number.isSafeInteger(rounded) || Math.abs(scaled - rounded) > 0.0000001) {
+    return undefined;
+  }
+  return rounded;
+}
+
+function Weight_gcd(a: number, b: number): number {
+  let left = Math.abs(a);
+  let right = Math.abs(b);
+  while (right !== 0) {
+    const remainder = left % right;
+    left = right;
+    right = remainder;
+  }
+  return left;
+}
+
+/**
+ * Calculates the plate stacks for a complete exercise in warm-up/work-set order. The regular single-target
+ * calculator remains the source of truth for load rounding and also supplies the always-valid fallback stacks.
+ */
+export function Weight_calculatePlatesSequence(
+  allWeights: IWeight[],
+  settings: ISettings,
+  units: IUnit,
+  exerciseType: IExerciseType
+): IWeightPlatesResult[] {
+  const fallback = allWeights.map((weight) => Weight_calculatePlates(weight, settings, weight.unit, exerciseType));
+  if (!USE_OPTIMIZED_PLATE_CALCULATOR || fallback.length === 0) {
+    return fallback;
+  }
+
+  const equipmentData = Equipment_getEquipmentDataForExerciseType(settings, exerciseType);
+  const multiplier = equipmentData?.multiplier ?? 0;
+  if (
+    equipmentData == null ||
+    equipmentData.isFixed ||
+    !Number.isSafeInteger(multiplier) ||
+    multiplier <= 0 ||
+    allWeights.some((weight) => weight.unit !== units)
+  ) {
+    return fallback;
+  }
+
+  try {
+    const byMilliWeight = new Map<number, { weight: IWeight; maxCount: number }>();
+    for (const plate of equipmentData.plates) {
+      if (plate.weight.unit !== units || plate.num < multiplier) {
+        continue;
+      }
+      const milliWeight = Weight_toMilliUnits(plate.weight.value);
+      const maxCount = Math.floor(plate.num / multiplier);
+      if (milliWeight == null || milliWeight <= 0 || !Number.isSafeInteger(maxCount)) {
+        return fallback;
+      }
+      const existing = byMilliWeight.get(milliWeight);
+      if (existing == null) {
+        byMilliWeight.set(milliWeight, { weight: plate.weight, maxCount });
+      } else if (Number.isSafeInteger(existing.maxCount + maxCount)) {
+        existing.maxCount += maxCount;
+      } else {
+        return fallback;
+      }
+    }
+
+    const plateTypes = Array.from(byMilliWeight.entries())
+      .map(([milliWeight, plate]) => ({ milliWeight, ...plate }))
+      .sort((a, b) => b.milliWeight - a.milliWeight);
+    if (plateTypes.length === 0) {
+      return fallback;
+    }
+    const indexByMilliWeight = new Map(plateTypes.map((plate, index) => [plate.milliWeight, index]));
+    const initialStacks: number[][] = [];
+    const targets: number[] = [];
+    for (const result of fallback) {
+      const stack: number[] = [];
+      let target = 0;
+      for (const plate of result.plates) {
+        const milliWeight = Weight_toMilliUnits(plate.weight.value);
+        if (milliWeight == null || plate.num % multiplier !== 0) {
+          return fallback;
+        }
+        const plateIndex = indexByMilliWeight.get(milliWeight);
+        if (plateIndex == null) {
+          return fallback;
+        }
+        const count = plate.num / multiplier;
+        if (!Number.isSafeInteger(count) || stack.length + count > MAX_OPTIMIZER_STACK_PLATES) {
+          return fallback;
+        }
+        for (let index = 0; index < count; index += 1) {
+          if (!Number.isSafeInteger(target + milliWeight)) {
+            return fallback;
+          }
+          stack.push(plateIndex);
+          target += milliWeight;
+        }
+      }
+      initialStacks.push(stack);
+      targets.push(target);
+    }
+
+    let divisor = 0;
+    for (const value of [...plateTypes.map((plate) => plate.milliWeight), ...targets]) {
+      divisor = Weight_gcd(divisor, value);
+    }
+    if (divisor <= 0) {
+      return fallback;
+    }
+
+    const optimized = PlateOptimizer_optimize({
+      plateWeights: plateTypes.map((plate) => plate.milliWeight / divisor),
+      maxPlateCounts: plateTypes.map((plate) => plate.maxCount),
+      targets: targets.map((target) => target / divisor),
+      initialStacks,
+    });
+
+    return fallback.map((result, targetIndex) => {
+      const stack = optimized.stacks[targetIndex];
+      const plates: IPlate[] = [];
+      for (const plateIndex of stack) {
+        const plateType = plateTypes[plateIndex];
+        const previous = plates[plates.length - 1];
+        if (previous != null && Weight_eqeq(previous.weight, plateType.weight)) {
+          previous.num += multiplier;
+        } else {
+          plates.push({ weight: plateType.weight, num: multiplier });
+        }
+      }
+      return { ...result, plates };
+    });
+  } catch (_error) {
+    return fallback;
+  }
+}
+
+export function Weight_calculatePlatesForSets(
+  sets: ISet[],
+  settings: ISettings,
+  exerciseType: IExerciseType
+): Map<string, IWeightPlatesResult> {
+  const weightedSets = sets.flatMap((set) => {
+    const weight = set.completedWeight ?? set.weight;
+    return weight == null ? [] : [{ id: set.id, weight }];
+  });
+  const unit = weightedSets[0]?.weight.unit ?? settings.units;
+  const results = Weight_calculatePlatesSequence(
+    weightedSets.map((set) => set.weight),
+    settings,
+    unit,
+    exerciseType
+  );
+  return new Map<string, IWeightPlatesResult>(
+    weightedSets.map((set, index) => [set.id, results[index]] as [string, IWeightPlatesResult])
+  );
 }
 
 export function Weight_abs(weight: IWeight): IWeight {

--- a/src/utils/liveActivityManager.ts
+++ b/src/utils/liveActivityManager.ts
@@ -4,7 +4,12 @@ import { Program_evaluate, Program_getProgramExercise } from "../models/program"
 import { ProgramExercise_hasUserPromptedVars } from "../models/programExercise";
 import { Progress_shouldShowAmrapModal, Progress_getNextEntry } from "../models/progress";
 import { ISetsStatus, Reps_setsStatus, Reps_findNextSetIndex } from "../models/set";
-import { Weight_calculatePlates, Weight_print, Weight_formatOneSide } from "../models/weight";
+import {
+  Weight_calculatePlates,
+  Weight_calculatePlatesForSets,
+  Weight_print,
+  Weight_formatOneSideOrdered,
+} from "../models/weight";
 import { IPlannerProgramExercise } from "../pages/planner/models/types";
 import { IHistoryRecord, IProgram, ISettings, ISubscription } from "../types";
 import { n } from "./math";
@@ -89,9 +94,11 @@ export function LiveActivityManager_getLiveActivityEntry(
   }
   const isNextSetWarmup = setIndex < entry.warmupSets.length;
   const weightForPlates = set.completedWeight ?? set.weight;
-  const plates = weightForPlates
-    ? Weight_calculatePlates(weightForPlates, settings, weightForPlates.unit || settings.units, entry.exercise)
-    : undefined;
+  const plates =
+    Weight_calculatePlatesForSets(allSets, settings, entry.exercise).get(set.id) ??
+    (weightForPlates
+      ? Weight_calculatePlates(weightForPlates, settings, weightForPlates.unit || settings.units, entry.exercise)
+      : undefined);
   let exerciseImageUrl = ExerciseImageUtils_url(exercise, "small", settings);
   if (exerciseImageUrl) {
     exerciseImageUrl = UrlUtils_build(exerciseImageUrl, __HOST__)?.toString();
@@ -129,7 +136,9 @@ export function LiveActivityManager_getLiveActivityEntry(
     targetRPE: set.rpe != null ? `${n(set.rpe)}${set.logRpe ? "+" : ""}` : undefined,
     targetTimer: set.timer != null ? set.timer.toString() : undefined,
     plates:
-      (plates?.plates || []).length > 0 ? Weight_formatOneSide(settings, plates?.plates || [], entry.exercise) : "None",
+      (plates?.plates || []).length > 0
+        ? Weight_formatOneSideOrdered(settings, plates?.plates || [], entry.exercise)
+        : "None",
     currentWeight: currentWeight != null ? Weight_print(currentWeight) : undefined,
     currentReps: currentReps != null ? currentReps.toString() : undefined,
     isWarmup: isNextSetWarmup,

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -56,8 +56,10 @@ import { getLatestMigrationVersion } from "../migrations/migrations";
 import { runMigrations, unrunMigrations } from "../migrations/runner";
 import { ExerciseImageUtils_url } from "../models/exerciseImage";
 import {
+  IWeightPlatesResult,
   Weight_calculatePlates,
-  Weight_formatOneSide,
+  Weight_calculatePlatesForSets,
+  Weight_formatOneSideOrdered,
   Weight_increment,
   Weight_decrement,
   Weight_round,
@@ -234,15 +236,16 @@ function setToWatchSet(
   exerciseType: IExerciseType,
   settings: ISettings,
   isWarmup: boolean,
-  isUnilateral: boolean
+  isUnilateral: boolean,
+  plateResult?: IWeightPlatesResult
 ): IWatchSet {
   let plates: string | undefined;
   const weightForPlates = set.completedWeight ?? set.weight;
   if (weightForPlates) {
     const unit = weightForPlates.unit;
-    const { plates: platesArr } = Weight_calculatePlates(weightForPlates, settings, unit, exerciseType);
+    const { plates: platesArr } = plateResult ?? Weight_calculatePlates(weightForPlates, settings, unit, exerciseType);
     if (platesArr.length > 0) {
-      plates = Weight_formatOneSide(settings, platesArr, exerciseType);
+      plates = Weight_formatOneSideOrdered(settings, platesArr, exerciseType);
     }
   }
   return {
@@ -464,10 +467,14 @@ class LiftosaurWatch {
     const exercise = Exercise_get(entry.exercise, settings.exercises);
     const imageUrl = ExerciseImageUtils_url(exercise, "small", settings);
     const isUnilateral = Exercise_getIsUnilateral(entry.exercise, settings);
+    const allSets = [...(entry.warmupSets || []), ...entry.sets];
+    const plateResults = Weight_calculatePlatesForSets(allSets, settings, entry.exercise);
     const warmupSets = (entry.warmupSets || []).map((set) =>
-      setToWatchSet(set, entry.exercise, settings, true, isUnilateral)
+      setToWatchSet(set, entry.exercise, settings, true, isUnilateral, plateResults.get(set.id))
     );
-    const workoutSets = entry.sets.map((set) => setToWatchSet(set, entry.exercise, settings, false, isUnilateral));
+    const workoutSets = entry.sets.map((set) =>
+      setToWatchSet(set, entry.exercise, settings, false, isUnilateral, plateResults.get(set.id))
+    );
     return {
       id: Exercise_toKey(entry.exercise),
       name: exercise.name,

--- a/test/plateOptimizer.test.ts
+++ b/test/plateOptimizer.test.ts
@@ -1,0 +1,293 @@
+import "mocha";
+import { expect } from "chai";
+import { IPlateOptimizerResult, PlateOptimizer_optimize } from "../src/models/plateOptimizer";
+
+function stackWeight(stack: number[], plateWeights: number[]): number {
+  return stack.reduce((total, plateIndex) => total + plateWeights[plateIndex], 0);
+}
+
+function verifyResult(
+  result: IPlateOptimizerResult,
+  plateWeights: number[],
+  maxPlateCounts: number[],
+  targets: number[]
+): void {
+  expect(result.stacks.map((stack) => stackWeight(stack, plateWeights))).to.eql(targets);
+  for (const stack of result.stacks) {
+    const counts = new Array(plateWeights.length).fill(0);
+    for (const plateIndex of stack) {
+      counts[plateIndex] += 1;
+      expect(counts[plateIndex]).to.be.at.most(maxPlateCounts[plateIndex]);
+    }
+  }
+
+  const stack: number[] = [];
+  const counts = new Array(plateWeights.length).fill(0);
+  let targetIndex = 0;
+  const consumeTargets = (): void => {
+    const weight = stackWeight(stack, plateWeights);
+    while (targetIndex < targets.length && weight === targets[targetIndex]) {
+      targetIndex += 1;
+    }
+  };
+  consumeTargets();
+  for (const operation of result.operations) {
+    if (operation.type === "push") {
+      stack.push(operation.plateIndex);
+      counts[operation.plateIndex] += 1;
+      expect(counts[operation.plateIndex]).to.be.at.most(maxPlateCounts[operation.plateIndex]);
+    } else {
+      expect(stack[stack.length - 1]).to.equal(operation.plateIndex);
+      stack.pop();
+      counts[operation.plateIndex] -= 1;
+    }
+    consumeTargets();
+  }
+  expect(targetIndex).to.equal(targets.length);
+  expect(stack).to.eql([]);
+  expect(result.actionCount).to.equal(result.operations.length);
+}
+
+function commonPrefixLength(a: number[], b: number[]): number {
+  let index = 0;
+  while (index < a.length && index < b.length && a[index] === b[index]) {
+    index += 1;
+  }
+  return index;
+}
+
+function distance(a: number[], b: number[]): number {
+  return a.length + b.length - 2 * commonPrefixLength(a, b);
+}
+
+function enumerateStacks(plateWeights: number[], maxPlateCounts: number[]): number[][] {
+  const result: number[][] = [];
+  const counts = new Array(plateWeights.length).fill(0);
+  const stack: number[] = [];
+  const visit = (): void => {
+    result.push([...stack]);
+    for (let plateIndex = 0; plateIndex < plateWeights.length; plateIndex += 1) {
+      if (counts[plateIndex] < maxPlateCounts[plateIndex]) {
+        counts[plateIndex] += 1;
+        stack.push(plateIndex);
+        visit();
+        stack.pop();
+        counts[plateIndex] -= 1;
+      }
+    }
+  };
+  visit();
+  return result;
+}
+
+function exhaustiveCost(plateWeights: number[], maxPlateCounts: number[], targets: number[]): number {
+  const stacks = enumerateStacks(plateWeights, maxPlateCounts);
+  let previous = new Map<string, { stack: number[]; cost: number }>();
+  previous.set("", { stack: [], cost: 0 });
+  for (const target of targets) {
+    const candidates = stacks.filter((stack) => stackWeight(stack, plateWeights) === target);
+    const next = new Map<string, { stack: number[]; cost: number }>();
+    for (const candidate of candidates) {
+      let best = Infinity;
+      for (const value of previous.values()) {
+        best = Math.min(best, value.cost + distance(value.stack, candidate));
+      }
+      next.set(candidate.join(","), { stack: candidate, cost: best });
+    }
+    previous = next;
+  }
+  let best = Infinity;
+  for (const value of previous.values()) {
+    best = Math.min(best, value.cost + value.stack.length);
+  }
+  return best;
+}
+
+function firstStackForTarget(plateWeights: number[], maxPlateCounts: number[], target: number): number[] {
+  const stack = enumerateStacks(plateWeights, maxPlateCounts).find(
+    (candidate) => stackWeight(candidate, plateWeights) === target
+  );
+  if (stack == null) {
+    throw new Error(`No stack found for target ${target}`);
+  }
+  return stack;
+}
+
+function descendingStackForTarget(plateWeights: number[], maxPlateCounts: number[], target: number): number[] {
+  const counts = new Array(plateWeights.length).fill(0);
+  const search = (plateIndex: number, remaining: number): boolean => {
+    if (plateIndex === plateWeights.length) {
+      return remaining === 0;
+    }
+    const maxCount = Math.min(maxPlateCounts[plateIndex], Math.floor(remaining / plateWeights[plateIndex]));
+    for (let count = maxCount; count >= 0; count -= 1) {
+      counts[plateIndex] = count;
+      if (search(plateIndex + 1, remaining - count * plateWeights[plateIndex])) {
+        return true;
+      }
+    }
+    counts[plateIndex] = 0;
+    return false;
+  };
+  if (!search(0, target)) {
+    throw new Error(`No descending stack found for target ${target}`);
+  }
+  return counts.flatMap((count, plateIndex) => new Array(count).fill(plateIndex));
+}
+
+describe("PlateOptimizer", () => {
+  it("orders plates to save actions across increasing targets", () => {
+    const plateWeights = [10, 5, 2];
+    const maxPlateCounts = [1, 1, 1];
+    const targets = [12, 17];
+    const result = PlateOptimizer_optimize({
+      plateWeights,
+      maxPlateCounts,
+      targets,
+      initialStacks: [
+        [0, 2],
+        [0, 1, 2],
+      ],
+    });
+
+    verifyResult(result, plateWeights, maxPlateCounts, targets);
+    expect(result.actionCount).to.equal(6);
+    expect(result.stacks).to.eql([
+      [0, 2],
+      [0, 2, 1],
+    ]);
+    expect(result.searchCompleted).to.equal(true);
+  });
+
+  it("handles decreases and repeated targets", () => {
+    const plateWeights = [10, 5, 2];
+    const maxPlateCounts = [1, 1, 1];
+    const targets = [17, 12, 12];
+    const result = PlateOptimizer_optimize({
+      plateWeights,
+      maxPlateCounts,
+      targets,
+      initialStacks: [
+        [0, 1, 2],
+        [0, 2],
+        [0, 2],
+      ],
+    });
+
+    verifyResult(result, plateWeights, maxPlateCounts, targets);
+    expect(result.actionCount).to.equal(6);
+    expect(result.stacks[1]).to.eql(result.stacks[2]);
+  });
+
+  it("returns the valid incumbent when a resource limit is reached", () => {
+    const plateWeights = [10, 5, 2];
+    const maxPlateCounts = [1, 1, 1];
+    const targets = [12, 17];
+    const initialStacks = [
+      [0, 2],
+      [0, 1, 2],
+    ];
+    const result = PlateOptimizer_optimize({
+      plateWeights,
+      maxPlateCounts,
+      targets,
+      initialStacks,
+      limits: { maxExpandedStates: 0 },
+    });
+
+    verifyResult(result, plateWeights, maxPlateCounts, targets);
+    expect(result.searchCompleted).to.equal(false);
+    expect(result.stacks).to.eql(initialStacks);
+    expect(result.actionCount).to.equal(8);
+  });
+
+  it("rejects an initial stack that is not physically feasible", () => {
+    expect(() =>
+      PlateOptimizer_optimize({
+        plateWeights: [10],
+        maxPlateCounts: [1],
+        targets: [20],
+        initialStacks: [[0, 0]],
+      })
+    ).to.throw("exceeds plate inventory");
+  });
+
+  it("matches exhaustive shortest paths for small deterministic problems", () => {
+    const fixtures = [
+      { plateWeights: [3, 2, 1], maxPlateCounts: [1, 1, 1], targets: [4, 6, 5] },
+      { plateWeights: [4, 3, 1], maxPlateCounts: [1, 1, 2], targets: [5, 8, 4] },
+      { plateWeights: [5, 2], maxPlateCounts: [1, 2], targets: [4, 7, 4] },
+      { plateWeights: [3, 1], maxPlateCounts: [2, 2], targets: [0, 4, 4, 6] },
+    ];
+
+    for (const fixture of fixtures) {
+      const initialStacks = fixture.targets.map((target) =>
+        firstStackForTarget(fixture.plateWeights, fixture.maxPlateCounts, target)
+      );
+      const result = PlateOptimizer_optimize({ ...fixture, initialStacks });
+      verifyResult(result, fixture.plateWeights, fixture.maxPlateCounts, fixture.targets);
+      expect(result.actionCount, JSON.stringify(fixture)).to.equal(
+        exhaustiveCost(fixture.plateWeights, fixture.maxPlateCounts, fixture.targets)
+      );
+    }
+  });
+
+  it("returns an empty plan for an empty target sequence", () => {
+    const result = PlateOptimizer_optimize({
+      plateWeights: [10],
+      maxPlateCounts: [1],
+      targets: [],
+      initialStacks: [],
+    });
+    expect(result).to.eql({ stacks: [], operations: [], actionCount: 0, searchCompleted: true, expandedStates: 0 });
+  });
+
+  it("completes an advanced pound sequence with the default gym inventory", () => {
+    // Units are 1.25lb after GCD reduction: 45, 25, 10, 5, 2.5 and 1.25lb plates.
+    const plateWeights = [36, 20, 8, 4, 2, 1];
+    const maxPlateCounts = [4, 2, 2, 2, 2, 1];
+    // Total bar weights: 45, 135, 225, 315, 405, 495, 455 and 495lb.
+    const targets = [0, 36, 72, 108, 144, 180, 164, 180];
+    const initialStacks = targets.map((target) => descendingStackForTarget(plateWeights, maxPlateCounts, target));
+    const baselineActions = initialStacks.reduce(
+      (total, stack, index) => total + distance(index === 0 ? [] : initialStacks[index - 1], stack),
+      initialStacks[initialStacks.length - 1].length
+    );
+    const result = PlateOptimizer_optimize({ plateWeights, maxPlateCounts, targets, initialStacks });
+
+    verifyResult(result, plateWeights, maxPlateCounts, targets);
+    expect(result.searchCompleted).to.equal(true);
+    expect(result.actionCount).to.be.at.most(baselineActions);
+  });
+
+  it("completes an advanced kilogram sequence with the default gym inventory", () => {
+    // Units are 0.25kg after GCD reduction: 20, 10, 5, 2.5, 1.25 and 0.5kg plates.
+    const plateWeights = [80, 40, 20, 10, 5, 2];
+    const maxPlateCounts = [4, 2, 2, 2, 2, 1];
+    // Total bar weights: 20, 60, 100, 140, 180, 220, 180 and 220kg.
+    const targets = [0, 80, 160, 240, 320, 400, 320, 400];
+    const initialStacks = targets.map((target) => descendingStackForTarget(plateWeights, maxPlateCounts, target));
+    const result = PlateOptimizer_optimize({ plateWeights, maxPlateCounts, targets, initialStacks });
+
+    verifyResult(result, plateWeights, maxPlateCounts, targets);
+    expect(result.searchCompleted).to.equal(true);
+  });
+
+  it("handles an elite expanded inventory within the configured bound", () => {
+    const plateWeights = [36, 20, 8, 4, 2, 1];
+    const maxPlateCounts = [12, 2, 2, 2, 2, 1];
+    // Reaches an 855lb total bar weight before a back-off set.
+    const targets = [0, 72, 144, 216, 288, 324, 288];
+    const initialStacks = targets.map((target) => descendingStackForTarget(plateWeights, maxPlateCounts, target));
+    const result = PlateOptimizer_optimize({
+      plateWeights,
+      maxPlateCounts,
+      targets,
+      initialStacks,
+      limits: { maxExpandedStates: 10 },
+    });
+
+    verifyResult(result, plateWeights, maxPlateCounts, targets);
+    expect(result.expandedStates).to.be.at.most(10);
+  });
+});

--- a/test/weight.test.ts
+++ b/test/weight.test.ts
@@ -6,6 +6,8 @@ import {
   Weight_calculatePlates,
   Weight_platesWeight,
   Weight_formatOneSide,
+  Weight_formatOneSideOrdered,
+  Weight_calculatePlatesSequence,
   Weight_strictParse,
 } from "../src/models/weight";
 import { IPlate, ISettings } from "../src/types";
@@ -131,6 +133,114 @@ describe("Weight", () => {
     });
   });
 
+  describe(".calculatePlatesSequence()", () => {
+    it("preserves a useful inner stack across increasing targets", () => {
+      const settings = buildSettings(
+        [
+          { weight: Weight_build(10, "lb"), num: 2 },
+          { weight: Weight_build(5, "lb"), num: 2 },
+          { weight: Weight_build(2, "lb"), num: 2 },
+        ],
+        0
+      );
+      const results = Weight_calculatePlatesSequence(
+        [Weight_build(24, "lb"), Weight_build(34, "lb")],
+        settings,
+        "lb",
+        exerciseType
+      );
+
+      expect(results.map((result) => result.totalWeight)).to.eql([Weight_build(24, "lb"), Weight_build(34, "lb")]);
+      expect(results[1].plates).to.eql([
+        { weight: Weight_build(10, "lb"), num: 2 },
+        { weight: Weight_build(2, "lb"), num: 2 },
+        { weight: Weight_build(5, "lb"), num: 2 },
+      ]);
+      expect(Weight_formatOneSideOrdered(settings, results[1].plates, exerciseType)).to.equal("10/2/5");
+      expect(Weight_formatOneSide(settings, results[1].plates, exerciseType)).to.equal("10/5/2");
+    });
+
+    it("retains the conventional descending answer when ordering saves no actions", () => {
+      const settings = buildSettings(
+        [
+          { weight: Weight_build(10, "lb"), num: 2 },
+          { weight: Weight_build(5, "lb"), num: 2 },
+          { weight: Weight_build(2, "lb"), num: 2 },
+        ],
+        0
+      );
+      const result = Weight_calculatePlatesSequence([Weight_build(24, "lb")], settings, "lb", exerciseType)[0];
+      expect(result.plates).to.eql([
+        { weight: Weight_build(10, "lb"), num: 2 },
+        { weight: Weight_build(2, "lb"), num: 2 },
+      ]);
+    });
+
+    it("uses exact gram units for kilogram plates", () => {
+      const settings = buildSettings(
+        [
+          { weight: Weight_build(10, "kg"), num: 2 },
+          { weight: Weight_build(2.5, "kg"), num: 2 },
+          { weight: Weight_build(1.25, "kg"), num: 2 },
+        ],
+        0
+      );
+      const results = Weight_calculatePlatesSequence(
+        [Weight_build(22.5, "kg"), Weight_build(27.5, "kg")],
+        settings,
+        "kg",
+        exerciseType
+      );
+
+      expect(results.map((result) => result.totalWeight)).to.eql([Weight_build(22.5, "kg"), Weight_build(27.5, "kg")]);
+      expect(Weight_formatOneSideOrdered(settings, results[1].plates, exerciseType)).to.equal("10/1.25/2.5");
+    });
+
+    it("keeps the legacy result for plate precision below one milli-unit", () => {
+      const settings = buildSettings([{ weight: Weight_build(0.3333, "lb"), num: 2 }], 0);
+      const result = Weight_calculatePlatesSequence([Weight_build(0.6666, "lb")], settings, "lb", exerciseType)[0];
+      expect(result.plates).to.eql([{ weight: Weight_build(0.3333, "lb"), num: 2 }]);
+      expect(result.totalWeight).to.eql(Weight_build(0.6666, "lb"));
+    });
+
+    it("preserves assisting equipment with a bodyweight bar", () => {
+      const settings = buildSettings(
+        [
+          { weight: Weight_build(10, "lb"), num: 4 },
+          { weight: Weight_build(5, "lb"), num: 2 },
+        ],
+        0
+      );
+      const equipment = settings.gyms[0].equipment.barbell!;
+      equipment.multiplier = 1;
+      equipment.useBodyweightForBar = true;
+      equipment.isAssisting = true;
+      settings.currentBodyweight = Weight_build(100, "lb");
+      const targets = [Weight_build(80, "lb"), Weight_build(70, "lb")];
+      const results = Weight_calculatePlatesSequence(targets, settings, "lb", exerciseType);
+
+      expect(results.map((result) => result.totalWeight)).to.eql(targets);
+      expect(results.map((result) => result.platesWeight)).to.eql([Weight_build(-20, "lb"), Weight_build(-30, "lb")]);
+    });
+
+    it("handles intermediate and advanced sequences with the default inventory", () => {
+      const settings = buildSettings([
+        { weight: Weight_build(45, "lb"), num: 8 },
+        { weight: Weight_build(25, "lb"), num: 4 },
+        { weight: Weight_build(10, "lb"), num: 4 },
+        { weight: Weight_build(5, "lb"), num: 4 },
+        { weight: Weight_build(2.5, "lb"), num: 4 },
+        { weight: Weight_build(1.25, "lb"), num: 2 },
+      ]);
+      const targets = [45, 135, 225, 315, 405, 495, 455, 495].map((value) => Weight_build(value, "lb"));
+      const results = Weight_calculatePlatesSequence(targets, settings, "lb", exerciseType);
+      expect(results.map((result) => result.totalWeight)).to.eql(targets);
+
+      const legacy = targets.map((target) => Weight_calculatePlates(target, settings, "lb", exerciseType));
+      expect(sequenceActionCount(results, 2)).to.be.at.most(sequenceActionCount(legacy, 2));
+    });
+  });
+
   describe(".platesWeight()", () => {
     it("calculates properly", () => {
       const plates = [
@@ -171,3 +281,20 @@ describe("Weight", () => {
     });
   });
 });
+
+function sequenceActionCount(results: { plates: IPlate[] }[], multiplier: number): number {
+  let actions = 0;
+  let previous: number[] = [];
+  for (const result of [...results, { plates: [] }]) {
+    const current = result.plates.flatMap((plate) =>
+      new Array(Math.floor(plate.num / multiplier)).fill(plate.weight.value)
+    );
+    let retained = 0;
+    while (retained < previous.length && retained < current.length && previous[retained] === current[retained]) {
+      retained += 1;
+    }
+    actions += previous.length + current.length - 2 * retained;
+    previous = current;
+  }
+  return actions;
+}

--- a/tests/optimizedPlates.spec.ts
+++ b/tests/optimizedPlates.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test";
+import {
+  PlaywrightUtils_clearCodeMirror,
+  PlaywrightUtils_createProgram,
+  PlaywrightUtils_disableSubscriptions,
+  PlaywrightUtils_disableTours,
+  PlaywrightUtils_typeCodeMirror,
+  startpage,
+} from "./playwrightUtils";
+
+test("shows optimized plate stacks from the bar outward", async ({ page }) => {
+  await page.goto(startpage + "?skipintro=1&nosync=true");
+  await PlaywrightUtils_disableTours(page);
+  await PlaywrightUtils_createProgram(page, "Optimized Plates");
+  await PlaywrightUtils_disableSubscriptions(page);
+
+  await page.getByTestId("tab-edit").click();
+  await page.getByTestId("editor-v2-full-program").click();
+  await PlaywrightUtils_clearCodeMirror(page, "planner-editor");
+  await PlaywrightUtils_typeCodeMirror(
+    page,
+    "planner-editor",
+    `# Week 1
+## Day 1
+Bench Press / 1x5 50lb, 1x5 70lb / warmup: none`
+  );
+  await page.getByTestId("save-program").click();
+
+  await page.getByTestId("footer-workout").click();
+  await page.getByTestId("start-workout").click();
+
+  const entry = page.getByTestId("entry-bench-press");
+  await expect(entry.getByTestId("plates-list")).toHaveText("2.5");
+
+  await entry.getByText("Target", { exact: true }).click();
+  await entry.getByText("Previous Set", { exact: true }).click();
+  await expect(entry.getByTestId("plates-list")).toHaveText(["2.5", "2.5", "2.5/10"]);
+
+  await entry.getByTestId("complete-set").first().click();
+  await expect(entry.getByTestId("plates-list").first()).toHaveText("2.5/10");
+});


### PR DESCRIPTION
 ## Context

  Related to #199.

  This is a worked implementation of sequence-aware plate loading. It is intended
  as an example of how this problem could be solved. Everything is up for criticism.

  The existing plate calculator is intentionally preserved. It is fast, widely
  used, and remains the source of truth and fallback for every target weight.

  ## User-visible behavior chnages

  When consecutive sets can share an inner plate stack, the plate display may use
  a non-descending order to reduce physical plate changes.

  For example, with a 45lb bar:

| Target | Plates per side, bar outward |
| ------ | ----------------------------- |
| 50lb | `2.5`|
| 70lb | `2.5/10` |

  The second set only requires pushing a 10lb plate. Conventional descending order
  would require removing the 2.5, pushing the 10, and replacing the 2.5.

  The UI continues to show the complete stack rather than only the change. This
  means the instruction remains correct if the user performs sets out of order;
  only the action savings depend on following the planned sequence.

  ## Design

  The optimizer is isolated in `src/models/plateOptimizer.ts` and has no knowledge
  of exercises, settings, pounds, kilograms, React, or application persistence.

  Its graph is implicit:

  - A stack is ordered from the bar outward.
  - Pushing or popping one outermost plate is an edge with cost 1.
  - A search state is `(targetIndex, orderedStack)`.
  - A target is recorded at zero cost when the stack has its required weight.
  - The goal is to visit every target in order and return to the empty stack.

  This is the single labelled shortest-path search suggested in #199. The
  implementation uses A* rather than Dijkstra so optimistic lower bounds can avoid
  exploring obviously unhelpful stacks.

  The graph is generated as needed; possible stacks and permutations are not
  precomputed.

  ## Reliability and bounded execution

  Before optimization, the existing calculator produces one valid stack for every
  target. Connecting those stacks and unloading the final one creates a complete
  **incumbent** plan.

  That incumbent is:

  - the upper bound used to prune search;
  - the result returned if optimization cannot run;
  - the result returned if a resource limit is reached;
  - retained when an alternative ordering would not strictly reduce actions.

  The optimizer has fixed bounds for:

  - relaxed DP cells;
  - lower-bound precomputation;
  - expanded states;
  - stored states;
  - priority queue size.

  An expensive or unusual input therefore falls back to a complete conventional
  plan rather than blocking the UI.

  The entire feature can also be disabled with:

  `const USE_OPTIMIZED_PLATE_CALCULATOR = false;`

  No user configuration or stored-data migration is introduced.

  ## Application boundary

  `Weight_calculatePlatesSequence` adapts application data to the pure optimizer:

  1. Run `Weight_calculatePlates` for every target.
  2. Preserve its rounding, bar-weight, bodyweight, assisting-equipment, and
     inventory semantics.
  3. Convert pounds to millipounds or kilograms to grams.
  4. Reduce integer weights by their greatest common divisor.
  5. Convert configured inventory to per-side quantities using the equipment
     multiplier.
  6. Run the optimizer when eligible.
  7. Convert the ordered stack back to `IPlate[]`.
  8. Return the legacy sequence on every unsupported or exceptional path.

  Plate types use temporary array indexes inside one call. This PR does not add
  persistent plate IDs or change the application data model.

  ## UX integration

  Sequence results are shared by:

  - the next-set plate calculator;
  - the workout set table;
  - Apple Watch workout data;
  - live activity data;
  - rest-timer notifications.

  A separate formatter preserves bar-outward order and only compresses adjacent
  identical plates. Existing sequence-unaware calculators keep conventional
  descending output.

  Workout help now states that plates are listed from the bar outward.

  ## Tests

  The pure optimizer tests cover:

  - increasing, decreasing, and repeated targets;
  - final unloading;
  - inventory enforcement;
  - resource-limited fallback;
  - operation replay;
  - comparison with an exhaustive shortest-path oracle for small cases;
  - pound and kilogram advanced-load inventories;
  - an elite bounded stress case.

  Weight-model tests cover:

  - exact millipound and gram conversion;
  - fractional plates;
  - assisting/bodyweight equipment;
  - conventional ordering when no action is saved;
  - fallback for unsupported precision;
  - intermediate and advanced sequences.

  A Mobile Safari test verifies the non-descending stack in both the next-set card
  and set table.

  Verified locally:

  - `npm run check`
  - 25 focused optimizer and weight tests
  - Mobile Safari optimized-plates test
  - Existing Mobile Safari custom-equipment plate expectation

  ## Non-goals and current limitations

  - No attempt is made to optimize transitions between different exercises.
  - Plate thickness and sleeve length are not modeled because the current
    equipment data does not contain them.
  - Every push and pop has equal cost; the model does not claim that handling a
    45lb plate takes the same effort as handling a 2.5lb plate.
  - Search completion/optimality metadata is internal and is not shown to users.
  - No settings or solver controls are exposed to users.

  ## Suggested review order

  1. `src/models/plateOptimizer.ts` — isolated algorithm and invariants.
  2. `test/plateOptimizer.test.ts` — behavior and exhaustive oracle.
  3. `src/models/weight.ts` — application adapter and fallback boundary.
  4. Workout/watch/live-activity integration.
  5. UX help and Playwright coverage.

Happy to work through alternatives/variants if this path lines up with your roadmap.