### PR TITLE
Fix GZCL Jacked & Tan 2.0 programming

### DIFF
--- a/programs/builtin/gzcl-jacked-and-tan-2.md
+++ b/programs/builtin/gzcl-jacked-and-tan-2.md
@@ -18,7 +18,7 @@ Before starting the program, please read the [program explanation](https://swole
 
 <!-- more -->
 
-Jacked & Tan 2.0 is a weightlifting program based on the **GZCL principle**, created by [Cody Lefever](https://www.gainzfever.com/). The GZCL name comes from his Reddit username - [u/gzcl](https://www.reddit.com/u/gzcl). It's a 12-week weightlifting program, following GZCL principles, and offering quite a lot of volume. It's designed both for hypertrophy and strength. It starts with lower intensity / higher volume, then progresses to higher intensity / lower volume. It's a fun program to run, offering somewhat unusual and interesting rep schemes, with testing for different RMs each workout.
+Jacked & Tan 2.0 is a strength-and-hypertrophy program based on the **GZCL principle**, created by [Cody Lefever](https://www.gainzfever.com/). The GZCL name comes from his Reddit username - [u/gzcl](https://www.reddit.com/u/gzcl). It's a 12-week program following GZCL principles and offering quite a lot of volume. It starts with lower intensity / higher volume, then progresses to higher intensity / lower volume. It's a fun program to run, offering somewhat unusual and interesting rep schemes, with testing for different RMs each workout.
 
 The program is primarily aimed at intermediates, who are likely to benefit most from its exercise variety, volume, and frequent hard efforts. Cody notes that lifters from novice to elite can benefit, provided they can manage the workload and autoregulate their rep-max attempts.
 
@@ -84,9 +84,11 @@ Unlike the converted T1 load suggestions, the T2a percentages below are literal 
 
 The weight/volume is also changing week over week in a wave pattern, adding sets on lower weights, to compensate drop in volume.
 
+T2a is planned reps-across work, not an AMRAP. You should be able to complete every prescribed rep, including the final set. If you miss the planned volume, reduce that movement's load or Training Max rather than forcing reps to failure.
+
 Before week 7, update borrowed T2a reference maxes from the T1 results found in week 6 where applicable. Reassess separate movement-specific TMs, such as Front Squat and Incline Bench Press, independently.
 
-Skip T2a in weeks 6 and 12, when you test the T1 1RM.
+Skip T2a in weeks 6 and 12; the program omits all T2 work during those T1 test weeks.
 
 :::exercise-example{exercise="deficitDeadlift" equipment="barbell" key="deficitdeadlift_barbell"}
 
@@ -152,6 +154,7 @@ t1 / used: none / 1x10 75%+ (10RM), 2x6 65% (TM 70%), 1x6+ 65% (TM 70%) / update
 
 // **T2a.**
 // Set each T2a exercise's 1RM to the TM it should reference, and reassess it before week 7.
+// Complete all prescribed reps; reduce this movement's load or TM if you miss them.
 t2a / used: none / 4x10 50% (TM 50%)
 
 // **T2b.** Same as in T1 - work up to 15RM, then record the weight.
@@ -307,8 +310,9 @@ t3 / 1x12 70%+ (12RM), 3x1+ 70% (MRS) / 60s
 
 # Week 6
 ## Day 1
-// **T1**. Work up to a conservative single you could confidently double. This set updates the exercise 1RM.
-t1 / 1x1 100%+ (1RM)
+// **T1**. Work up to a conservative single you could confidently double.
+// Liftosaur stores it as the exercise's working 1RM reference; do not grind an all-out max.
+t1 / 1x1 100%+ (single)
 // **T3.** Same as **T2b**, just 10RM
 t3 / 1x10 75%+ (10RM), 3x1+ 75% (MRS) / 60s
 

--- a/programs/builtin/gzcl-jacked-and-tan-2.md
+++ b/programs/builtin/gzcl-jacked-and-tan-2.md
@@ -12,7 +12,7 @@ duration: "60-90"
 goal: "strength_and_hypertrophy"
 ---
 
-A good next step after GZCLP. It's a twelve-week strength and hypertrophy training regimen that focuses on a higher volume and intensity approach, employing varying rep ranges and periodization to maximize muscle growth and strength gains.
+A good next step after GZCLP. It's a twelve-week hypertrophy and strength regimen that uses high volume, varied rep ranges, and periodization to prioritize muscle growth and work capacity while also building strength.
 
 Before starting the program, please read the [program explanation](https://swoleateveryheight.blogspot.com/2016/07/jacked-tan-20.html) first!
 
@@ -20,7 +20,7 @@ Before starting the program, please read the [program explanation](https://swole
 
 Jacked & Tan 2.0 is a weightlifting program based on the **GZCL principle**, created by [Cody Lefever](https://www.gainzfever.com/). The GZCL name comes from his Reddit username - [u/gzcl](https://www.reddit.com/u/gzcl). It's a 12-week weightlifting program, following GZCL principles, and offering quite a lot of volume. It's designed both for hypertrophy and strength. It starts with lower intensity / higher volume, then progresses to higher intensity / lower volume. It's a fun program to run, offering somewhat unusual and interesting rep schemes, with testing for different RMs each workout.
 
-It's an intermediate program, so you're going to find it most useful after your newbie gains are over. There's good variety in exercises, and a lot of people reported getting serious gains and new PRs after running this program.
+The program is primarily aimed at intermediates, who are likely to benefit most from its exercise variety, volume, and frequent hard efforts. Cody notes that lifters from novice to elite can benefit, provided they can manage the workload and autoregulate their rep-max attempts.
 
 You can run it after beginner [GZCLP](/programs/gzclp) program, or after beginner/intermediate [GZCL: The Rippler](/programs/gzcl-the-rippler) program.
 
@@ -34,7 +34,7 @@ Now, let's talk about exercises. Exercises in GZCL programs are split into **3 t
 
 - **T1**: These are main compound exercises (e.g., [{Squat}], [{Deadlift}], [{Bench Press}], [{Overhead Press}]). These exercises involve the highest intensity (i.e., the largest weights, about **85-100%** of your 2-3 rep max), but with lower volume (fewer reps and sets). Typically, you will perform 10-15 total reps, usually within **1-3 reps** per set.
 - **T2**: These are secondary compound exercises (e.g., [{Front Squat}], [{Romanian Deadlift}], [{Incline Bench Press}], etc). These exercises have lower intensity (lower weights), but higher volume (more reps and sets). You should pick exercises that will assist with your T1 exercises. These exercises are performed with **65-85%** of your 2-3 rep max, usually within **5-8 reps** per set.
-- **T3**: These are isolation exercises (e.g., [{Leg Press}], [{Seated Leg Curl}], [{Triceps Extension}], [{Lateral Raise}]). These exercises have the lowest intensity (lightest weights), but highest volume (most reps and sets). These are performed with less than **65%** of your 2-3 rep max, usually with **8 or more reps** per set.
+- **T3**: These are lighter accessory exercises (e.g., [{Leg Press}], [{Seated Leg Curl}], [{Triceps Extension}], [{Lateral Raise}], or rows). They often isolate smaller muscle groups, but bodyweight and lighter compound movements are also valid. T3 has the lowest intensity (lightest weights) and highest volume (most reps and sets), usually using **8 or more reps** per set.
 
 A useful rule of thumb is the **1:2:3 rule** - for every rep you perform in T1, do 2 reps in T2, and 3 in T3.
 
@@ -78,11 +78,13 @@ Note that first RM sets are approximate in this example
 
 ### T2a Exercise
 
-The T2a exercise weight is usually based on the T1 Training Max weight (since T2a exercises are auxiliary exercises to T1 ones). The exception is [{Front Squat}], which uses its own TM. Unlike the converted T1 load suggestions, the T2a percentages are literal TM percentages. Set each T2a exercise's 1RM in Exercise Stats to the TM it should use.
+Each T2a exercise needs an appropriate movement-specific Training Max. Cody defines that TM as a recent or reasonably estimated 2RM that you could lift on any given day. In the author workbook, close variations such as close-grip bench and deficit deadlift borrow the related main lift's TM, while movements with meaningfully different strength levels, including [{Front Squat}] and [{Incline Bench Press}], use their own TMs.
+
+Unlike the converted T1 load suggestions, the T2a percentages below are literal TM percentages. Liftoscript applies them to the selected exercise's 1RM field, so set each T2a exercise's 1RM in Exercise Stats to the TM or reference TM it should use.
 
 The weight/volume is also changing week over week in a wave pattern, adding sets on lower weights, to compensate drop in volume.
 
-Before week 7, update related T2a reference maxes from the 1RMs found in week 6 where applicable. Reassess movement-specific TMs, such as Front Squat, separately.
+Before week 7, update borrowed T2a reference maxes from the T1 results found in week 6 where applicable. Reassess separate movement-specific TMs, such as Front Squat and Incline Bench Press, independently.
 
 Skip T2a in weeks 6 and 12, when you test the T1 1RM.
 
@@ -108,7 +110,7 @@ You can run the GZCL: Jacked And Tan 2.0 program in the Liftosaur app.
 
 ### Is Jacked and Tan 2.0 good for beginners?
 
-No, Jacked and Tan 2.0 is an intermediate program best suited for lifters who have exhausted beginner linear progression. You should have at least a year of training experience and be comfortable estimating rep maxes. Run [GZCLP](/programs/gzclp) first if you're still making session-to-session progress.
+Cody says lifters from novice to elite can benefit from Jacked and Tan 2.0, but its high volume and autoregulated rep-max work make it most useful for intermediates who can estimate rep maxes and manage fatigue. If you're still making straightforward session-to-session progress, [GZCLP](/programs/gzclp) is usually the simpler place to start.
 
 ### How many days a week is Jacked and Tan 2.0?
 
@@ -136,6 +138,9 @@ Yes, especially T2b and T3 exercises. Pick movements that support your T1 lifts 
 // **T1**. Warm up to **10 RM** for the first set, then try a 10RM, tap the first
 // set and enter the 10RM weight you get. Then, do the drop sets (based on TM)
 t1 / used: none / 1x10 75%+ (10RM), 2x6 65% (TM 70%), 1x6+ 65% (TM 70%) / update: custom() {~
+  if (setIndex == 0) {
+    askweights[1] = 1
+  }
   if (week >= 7 && week <= 11 && setIndex == 1) {
     weights = completedWeights[1] * (week >= 10 ? 0.9 : 0.85)
   }

--- a/programs/builtin/gzcl-jacked-and-tan-2.md
+++ b/programs/builtin/gzcl-jacked-and-tan-2.md
@@ -57,7 +57,7 @@ The first set is a Rep Max set, where you have to work up to your Rep Max. For t
 
 If you missed, and chose the weight that is too heavy, and let's say you only could do 8 reps. Or too light, and you did 12 reps. That's okay! You'll get better at this later on, just record your weight/reps, and move to the drop sets.
 
-Drop sets are sets that are based on the Training Max. E.g. for week 1 it's 50% of TM, 10 reps each. Last set is As Many Reps As Possible (AMRAP) - try to do as many reps as possible (leaving 1-2 reps in the tan). It's a good way to push yourself, and also to see if you need to adjust TM - if you can get more than 12 reps there, you may want to consider increasing TM.
+Drop sets are sets that are based on the Training Max. For example, in week 1 you do 3 sets of 6 at 70% of TM. The last set is As Many Reps As Possible (AMRAP) - try to do as many reps as possible (leaving 1-2 reps in the tank). It's a good way to push yourself, and also to see if you need to adjust TM - if you can get more than 12 reps there, you may want to consider increasing TM.
 
 On week 6, you measure your 1RM. You don't do any T1 drop sets (and any T2 exercises).
 
@@ -76,20 +76,22 @@ Note that first RM sets are approximate in this example
 
 ### T2a Exercise
 
-The T2a exercise weight is usually based on the T1 Training Max weight (since T2a exercises are auxiliary exercises to T1 ones). The exception is [{Front Squat}], which is using its own TM.
+The T2a exercise weight is usually based on the T1 Training Max weight (since T2a exercises are auxiliary exercises to T1 ones). The exception is [{Front Squat}], which is using its own TM. Liftoscript calculates percentages from each selected exercise's 1RM field, so set each T2a exercise's 1RM in Exercise Stats to the TM it should use.
 
 The weight/volume is also changing week over week in a wave pattern, adding sets on lower weights, to compensate drop in volume.
 
-You skip the exercise on the Week 6 and Week 12, when you measure your 1RM for T1 exercise.
+Before week 7, update related T2a reference maxes from the 1RMs found in week 6 where applicable. Reassess movement-specific TMs, such as Front Squat, separately.
+
+Skip T2a in weeks 6 and 12, when you test the T1 1RM.
 
 :::exercise-example{exercise="deficitDeadlift" equipment="barbell" key="deficitdeadlift_barbell"}
 
 
 ### T2b and T3 Exercises
 
-T2b and T3 exercises are pretty similar to each other, they just use different first set RM value. So, for the first set, you attempt to do RM for the reps of that set (similar to T1), record the weight, and then you do the so-called Max Rep Sets (MRS). Simply, try to do as many reps as possible with the same weight as you did for the first set. For the 2nd, 3rd, etc Max Reps Set you likely will be able to do less and less reps, but that's okay and expected, as you're accumulating fatigue.
+T2b and T3 exercises are pretty similar to each other, they just use different first set RM value. So, for the first set, you attempt to do RM for the reps of that set (similar to T1), record the weight, and then you do the so-called Max Rep Sets (MRS). Simply, try to do as many reps as possible with the same weight as you did for the first set, leaving 1-2 reps in the tank and resting 30-60 seconds between sets. For the 2nd, 3rd, etc Max Reps Set you likely will be able to do less and less reps, but that's okay and expected, as you're accumulating fatigue.
 
-You skip these exercises on the Week 7 and Week 12
+T2b rests in weeks 6, 11, and 12. T3 rests in weeks 7 and 12.
 
 :::exercise-example{exercise="tricepsPushdown" equipment="cable" key="tricepspushdown_cable"}
 
@@ -130,7 +132,7 @@ Yes, especially T2b and T3 exercises. Pick movements that support your T1 lifts 
 # Week 1
 ## Day 1
 // **T1**. Warmup up to **10 RM** for the first set, then try a 10RM, tap the first
-// set and enter the 10RM weight you get. Then, do the drop sets (based on 1RM)
+// set and enter the 10RM weight you get. Then, do the drop sets (based on TM)
 t1 / used: none / 1x10 75%+ (10RM), 2x6 65% (TM 70%), 1x6+ 65% (TM 70%) / update: custom() {~
   if (week >= 7 && week <= 11 && setIndex == 1) {
     weights = completedWeights[1] * (week >= 10 ? 0.9 : 0.85)
@@ -142,14 +144,15 @@ t1 / used: none / 1x10 75%+ (10RM), 2x6 65% (TM 70%), 1x6+ 65% (TM 70%) / update
 ~}
 
 // **T2a.**
+// Set each T2a exercise's 1RM to the TM it should reference, and reassess it before week 7.
 t2a / used: none / 4x10 50% (TM 50%)
 
 // **T2b.** Same as in T1 - work up to 15RM, then record the weight.
 // Then, do MRS (Max Rep Sets) - i.e. AMRAP, as many reps as possible
-t2b / used: none / 1x15 60%+ (15RM), 3x10+ 60% (MRS) / update: custom() {~ if (setIndex == 1) { weights = completedWeights[1] } ~}
+t2b / used: none / 1x15 60%+ (15RM), 3x1+ 60% (MRS) / 60s / update: custom() {~ if (setIndex == 1) { weights = completedWeights[1] } ~}
 
-// **T3.**. Similar to T2b, but different first set 1RM weight
-t3 / used: none / 1x20 50%+ (20RM), 3x10+ 50% (MRS) / update: custom() {~ if (setIndex == 1) { weights = completedWeights[1] } ~}
+// **T3.** Similar to T2b, but with a different first-set RM target.
+t3 / used: none / 1x20 50%+ (20RM), 3x1+ 50% (MRS) / 60s / update: custom() {~ if (setIndex == 1) { weights = completedWeights[1] } ~}
 
 // ...t1
 Squat[1,1-12] / ...t1
@@ -215,14 +218,14 @@ Incline Curl[4,1-6] / ...t3
 # Week 2
 ## Day 1
 // **T1**. Warmup up to **8 RM** for the first set, then try a 8RM, tap the first
-// set and enter the 8RM weight you get. Then, do the drop sets (based on 1RM)
-t1 / 1x8 80%+ (8RM), 2x6 70% (TM 75%), 1x6+ 70% (TM 75%)
+// set and enter the 8RM weight you get. Then, do the drop sets (based on TM)
+t1 / 1x8 80%+ (8RM), 2x5 70% (TM 75%), 1x5+ 70% (TM 75%)
 t2a / 4x8 60% (TM 60%)
 // **T2b.** Same as in T1 - work up to 12RM, then record the weight.
 // Then, do MRS (Max Rep Sets) - i.e. AMRAP, as many reps as possible
-t2b / 1x12 68%+ (12RM), 3x8+ 68% (MRS)
+t2b / 1x12 68%+ (12RM), 3x1+ 68% (MRS) / 60s
 // **T3.** Same as **T2b**, just 18RM
-t3 / 1x18 50%+ (18RM), 3x10+ 50% (MRS)
+t3 / 1x18 50%+ (18RM), 3x1+ 50% (MRS) / 60s
 
 ## Day 2
 
@@ -237,14 +240,14 @@ t3 / 1x18 50%+ (18RM), 3x10+ 50% (MRS)
 # Week 3
 ## Day 1
 // **T1**. Warmup up to **6 RM** for the first set, then try a 6RM, tap the first
-// set and enter the 6RM weight you get. Then, do the drop sets (based on 1RM)
+// set and enter the 6RM weight you get. Then, do the drop sets (based on TM)
 t1 / 1x6 85%+ (6RM), 2x4 75% (TM 80%), 1x4+ 75% (TM 80%)
 t2a / 4x6 70% (TM 70%)
 // **T2b.** Same as in T1 - work up to 10RM, then record the weight.
 // Then, do MRS (Max Rep Sets) - i.e. AMRAP, as many reps as possible
-t2b / 1x10 73%+ (10RM), 3x6+ 73% (MRS)
+t2b / 1x10 73%+ (10RM), 3x1+ 73% (MRS) / 60s
 // **T3.** Same as **T2b**, just 16RM
-t3 / 1x16 55%+ (16RM), 3x8+ 55% (MRS)
+t3 / 1x16 55%+ (16RM), 3x1+ 55% (MRS) / 60s
 
 ## Day 2
 
@@ -259,13 +262,13 @@ t3 / 1x16 55%+ (16RM), 3x8+ 55% (MRS)
 # Week 4
 ## Day 1
 // **T1**.
-t1 / 1x4 90%+ (4RM), 2x4 75% (TM 80%), 1x4+ 75% (TM 80%)
+t1 / 1x4 90%+ (4RM), 2x3 77.5% (TM 82.5%), 1x3+ 77.5% (TM 82.5%)
 // **T2a.**
-t2a / 5x4 70% (TM 70%)
+t2a / 5x4 75% (TM 75%)
 // **T2b.**
-t2b / 1x8 73%+ (8RM), 3x5+ 73% (MRS)
+t2b / 1x8 78%+ (8RM), 3x1+ 78% (MRS) / 60s
 // **T3.** Same as **T2b**, just 14RM
-t3 / 1x14 65%+ (14RM), 3x8+ 65% (MRS)
+t3 / 1x14 65%+ (14RM), 3x1+ 65% (MRS) / 60s
 
 ## Day 2
 
@@ -281,9 +284,9 @@ t3 / 1x14 65%+ (14RM), 3x8+ 65% (MRS)
 ## Day 1
 t1 / 1x2 95%+ (2RM), 3x2 80% (TM 85%), 1x2+ 80% (TM 85%)
 t2a / 7x2 80% (TM 80%)
-t2b / 1x6 83%+ (6RM), 3x3+ 83% (MRS)
+t2b / 1x6 83%+ (6RM), 3x1+ 83% (MRS) / 60s
 // **T3.** Same as **T2b**, just 12RM
-t3 / 1x12 70%+ (12RM), 3x7+ 70% (MRS)
+t3 / 1x12 70%+ (12RM), 3x1+ 70% (MRS) / 60s
 
 ## Day 2
 
@@ -300,7 +303,7 @@ t3 / 1x12 70%+ (12RM), 3x7+ 70% (MRS)
 // **T1**. Testing your 1RM! This set will update 1RM of this exercise.
 t1 / 1x1 100%+ (1RM)
 // **T3.** Same as **T2b**, just 10RM
-t3 / 1x10 75%+ (10RM), 3x5+ 75% (MRS)
+t3 / 1x10 75%+ (10RM), 3x1+ 75% (MRS) / 60s
 
 ## Day 2
 
@@ -317,22 +320,22 @@ t3 / 1x10 75%+ (10RM), 3x5+ 75% (MRS)
 // **T1**. It's start of the next cycle, where drop sets are based on your first set.
 // Work up to your 6RM, after that, do the drop sets, that are 85% of your new 6RM.
 t1 / 1x6 85%+ (6RM), 4x3 72.5% (6RM 85%), 1x3+ 72.5% (6RM 85%)
-t2a/ 6x5 70% (TM 70%)
-t2b / 1x12 68%+ (12RM), 3x8+ 68% (MRS)
+t2a / 5x6 70% (TM 70%)
+t2b / 1x12 68%+ (12RM), 3x1+ 68% (MRS) / 60s
 
-Deficit Deadlift[2,7-10] / ...t2a
+Deficit Deadlift[2,7-11] / ...t2a
 Incline Row[3,7-10] / ...t2b
 
 ## Day 2
-Bench Press Close Grip[2,7-10] / ...t2a
+Bench Press Close Grip[2,7-11] / ...t2a
 Shoulder Press[3,7-10] / ...t2b
 
 ## Day 3
-Front Squat[2,7-10] / ...t2a
+Front Squat[2,7-11] / ...t2a
 Lat Pulldown[3,7-10] / ...t2b
 
 ## Day 4
-Incline Bench Press[2,7-10] / ...t2a
+Incline Bench Press[2,7-11] / ...t2a
 Push Press[3,7-10] / ...t2b
 
 
@@ -343,48 +346,48 @@ t1 / 1x4 90%+ (4RM), 4x2 75% (4RM 85%), 1x2+ 75% (4RM 85%)
 // **T2a**.
 t2a / 5x5 75% (TM 75%)
 // **T2b**.
-t2b / 1x10 73%+ (10RM), 3x6+ 73% (MRS)
+t2b / 1x10 73%+ (10RM), 3x1+ 73% (MRS) / 60s
 // **T3.**
-t3 / 1x18 50%+ (18RM), 3x10+ 50% (MRS)
+t3 / 1x18 50%+ (18RM), 3x1+ 50% (MRS) / 60s
 
 // ...t3
-Triceps Pushdown[4,8-10] / ...t3
+Triceps Pushdown[4,8-11] / ...t3
 // ...t3
-Bent Over Row, Cable[4,8-10] / ...t3
+Bent Over Row, Cable[4,8-11] / ...t3
 // ...t3
-Hammer Curl, Dumbbell[4,8-10] / ...t3
+Hammer Curl, Dumbbell[4,8-11] / ...t3
 
 ## Day 2
 // ...t3
-Shrug[4,8-10] / ...t3
+Shrug[4,8-11] / ...t3
 // ...t3
-Pec Deck[4,8-10] / ...t3
+Pec Deck[4,8-11] / ...t3
 // ...t3
-Face Pull, Cable[4,8-10] / ...t3
+Face Pull, Cable[4,8-11] / ...t3
 
 ## Day 3
 // ...t3
-Leg Extension[4,8-10] / ...t3
+Leg Extension[4,8-11] / ...t3
 // ...t3
-Bent Over One Arm Row[4,8-10] / ...t3
+Bent Over One Arm Row[4,8-11] / ...t3
 // ...t3
-Bicep Curl, EZ Bar[4,8-10] / ...t3
+Bicep Curl, EZ Bar[4,8-11] / ...t3
 
 ## Day 4
 // ...t3
-Triceps Pushdown[4,8-10] / ...t3
+Triceps Pushdown[4,8-11] / ...t3
 // ...t3
-Shrug[4,8-10] / ...t3
+Shrug[4,8-11] / ...t3
 // ...t3
-Incline Curl[4,8-10] / ...t3
+Incline Curl[4,8-11] / ...t3
 
 
 # Week 9
 ## Day 1
 t1 / 1x2 95%+ (2RM), 4x1 80% (2RM 85%), 1x1+ 80% (2RM 85%)
 t2a / 5x4 80% (TM 80%)
-t2b / 1x8 78%+ (8RM), 3x4+ 78% (MRS)
-t3 / 1x16 55%+ (16RM), 3x8+ 55% (MRS)
+t2b / 1x8 78%+ (8RM), 3x1+ 78% (MRS) / 60s
+t3 / 1x16 55%+ (16RM), 3x1+ 55% (MRS) / 60s
 
 ## Day 2
 
@@ -400,8 +403,8 @@ t3 / 1x16 55%+ (16RM), 3x8+ 55% (MRS)
 ## Day 1
 t1 / 1x5 85%+ (5RM), 2x2 75% (5RM 90%), 1x2+ 75% (5RM 90%)
 t2a / 6x3 82.5% (TM 82.5%)
-t2b / 1x6 83%+ (6RM), 3x3+ 83% (MRS)
-t3 / 1x14 65%+ (14RM), 3x8+ 65% (MRS)
+t2b / 1x6 83%+ (6RM), 3x1+ 83% (MRS) / 60s
+t3 / 1x14 65%+ (14RM), 3x1+ 65% (MRS) / 60s
 
 ## Day 2
 
@@ -416,6 +419,8 @@ t3 / 1x14 65%+ (14RM), 3x8+ 65% (MRS)
 # Week 11
 ## Day 1
 t1 / 1x3 92%+ (3RM), 2x1 82% (3RM 90%), 1x1+ 82% (3RM 90%)
+t2a / 7x2 85% (TM 85%)
+t3 / 1x12 70%+ (12RM), 3x1+ 70% (MRS) / 60s
 
 ## Day 2
 

--- a/programs/builtin/gzcl-jacked-and-tan-2.md
+++ b/programs/builtin/gzcl-jacked-and-tan-2.md
@@ -78,7 +78,7 @@ Note that first RM sets are approximate in this example
 
 ### T2a Exercise
 
-Each T2a exercise needs an appropriate movement-specific Training Max. Cody defines that TM as a recent or reasonably estimated 2RM that you could lift on any given day. In the author workbook, close variations such as close-grip bench and deficit deadlift borrow the related main lift's TM, while movements with meaningfully different strength levels, including [{Front Squat}] and [{Incline Bench Press}], use their own TMs.
+Each T2a exercise needs an appropriate movement-specific Training Max. Cody defines that TM as a recent or reasonably estimated 2RM that you could lift on any given day. In the author workbook, close variations such as close-grip bench and deficit deadlift borrow the related main lift's TM, Front Squat uses a separate TM, and an independent Incline Bench TM field is provided. This Liftosaur variant programs both [{Front Squat}] and [{Incline Bench Press}] as T2a movements, so use their movement-specific TMs.
 
 Unlike the converted T1 load suggestions, the T2a percentages below are literal TM percentages. Liftoscript applies them to the selected exercise's 1RM field, so set each T2a exercise's 1RM in Exercise Stats to the TM or reference TM it should use.
 

--- a/programs/builtin/gzcl-jacked-and-tan-2.md
+++ b/programs/builtin/gzcl-jacked-and-tan-2.md
@@ -28,7 +28,7 @@ You can run it after beginner [GZCLP](/programs/gzclp) program, or after beginne
 
 Before diving in, here's some basic terminology:
 
-- **Rep Max**: This refers to the maximum weight you can lift for a given number of reps. For instance, if you can do 5 reps (and no more) with 100 kg, then your 5 rep max is 100 kg. When measuring this, you should not go to full failure, but stop when you can't maintain good form for another rep.
+- **Rep Max (RM)**: In this program, this is the heaviest weight you can lift for the target reps with clean form while keeping **1-2 reps in reserve**. It is not a failure set. If you reach the target and judge that one or two more clean reps were possible, you found the intended RM.
 
 Now, let's talk about exercises. Exercises in GZCL programs are split into **3 tiers**:
 
@@ -46,7 +46,9 @@ This is a very short description of the GZCL principle. For more information, an
 
 For the T1 exercise, we start with high volume and low intensity (high reps, lower weight), and progress to lower volume and higher intensity (lower reps, higher weight) - so called Linear Periodization.
 
-First, you need to define your training max (TM), which is approximately equal to your 2RM (2 Rep Max). It'll be the basis for your "drop sets" for T1 exercise. Drop sets are the sets that you do after the Rep Max set, which are based on percentage of TM.
+The official program uses a training max (TM), approximately equal to your 2RM (2 Rep Max), as the basis for the T1 "drop sets" performed after the Rep Max set.
+
+Liftoscript calculates percentages from an exercise's 1RM field. For **T1**, enter your true current 1RM, not your TM. This implementation estimates Cody's TM - an estimated daily 2RM - as 93.75% of true 1RM using the Epley formula, then rounds the converted percentages to the nearest 2.5 percentage points. The set labels show Cody's original TM percentages. If you know your personal TM, you can edit a drop-set weight to match the labeled percentage exactly.
 
 The first set is a Rep Max set, where you have to work up to your Rep Max. For the first week it's 10RM, for the second - 8RM, etc. So, to work up your 10RM, you need to guess your approximate 10RM weight, and then do "warmup" sets, that are not fatiguing, slowly increasing the weight. Like, let's say you guessed your 10RM for [{Bench Press}] is 185lb. So, you do:
 
@@ -55,11 +57,11 @@ The first set is a Rep Max set, where you have to work up to your Rep Max. For t
 - 3 reps with 135lb
 - 10 reps with 185lb
 
-If you missed, and chose the weight that is too heavy, and let's say you only could do 8 reps. Or too light, and you did 12 reps. That's okay! You'll get better at this later on, just record your weight/reps, and move to the drop sets.
+If you chose a weight that was too heavy and could only do 8 reps, or too light and reached 10 reps with more than two reps still in reserve, that's okay. Record what you did, adjust the later work if needed, and move to the drop sets.
 
-Drop sets are sets that are based on the Training Max. For example, in week 1 you do 3 sets of 6 at 70% of TM. The last set is As Many Reps As Possible (AMRAP) - try to do as many reps as possible (leaving 1-2 reps in the tank). It's a good way to push yourself, and also to see if you need to adjust TM - if you can get more than 12 reps there, you may want to consider increasing TM.
+Drop sets are sets that are based on the Training Max. For example, in week 1 you do 3 sets of 6 at 70% of TM. The last set is As Many Reps As Possible (AMRAP) - try to do as many reps as possible while leaving 1-2 reps in the tank. It's a good way to push yourself and gauge the drop-set intensity. If you get more than 12 reps on this set during the first mesocycle, Cody recommends increasing the later drop-set intensity.
 
-On week 6, you measure your 1RM. You don't do any T1 drop sets (and any T2 exercises).
+In week 6, work up to a conservative single that you could confidently double. Cody expects this to be within about 5% of your actual 1RM. You don't do any T1 drop sets or T2 exercises.
 
 After that, for the next 5 weeks, instead of %TM for the drop sets, you use percentage of your Rep Max for that week. E.g. on Week 7 you do your 6RM set first, and then the drop sets would be 85% of 6RM.
 
@@ -76,7 +78,7 @@ Note that first RM sets are approximate in this example
 
 ### T2a Exercise
 
-The T2a exercise weight is usually based on the T1 Training Max weight (since T2a exercises are auxiliary exercises to T1 ones). The exception is [{Front Squat}], which is using its own TM. Liftoscript calculates percentages from each selected exercise's 1RM field, so set each T2a exercise's 1RM in Exercise Stats to the TM it should use.
+The T2a exercise weight is usually based on the T1 Training Max weight (since T2a exercises are auxiliary exercises to T1 ones). The exception is [{Front Squat}], which uses its own TM. Unlike the converted T1 load suggestions, the T2a percentages are literal TM percentages. Set each T2a exercise's 1RM in Exercise Stats to the TM it should use.
 
 The weight/volume is also changing week over week in a wave pattern, adding sets on lower weights, to compensate drop in volume.
 
@@ -114,7 +116,7 @@ Jacked and Tan 2.0 is a 4-day program. Each day has a different T1 main lift (Sq
 
 ### How long is the Jacked and Tan 2.0 program?
 
-The program runs for 12 weeks. Weeks 1-5 build volume at increasing intensity, week 6 tests your 1RM, weeks 7-11 shift to intensity-focused work with drop sets based on your rep max, and week 12 is a final 1RM test.
+The program runs for 12 weeks. Weeks 1-5 build volume at increasing intensity, week 6 takes a conservative single you could confidently double, weeks 7-11 shift to intensity-focused work with drop sets based on your rep max, and week 12 is a final 1RM test.
 
 ### What should I run after Jacked and Tan 2.0?
 
@@ -122,23 +124,23 @@ You can run it again with updated maxes, or switch to [The Rippler](/programs/gz
 
 ### How do the Rep Max sets work in Jacked and Tan 2.0?
 
-For the T1 first set each week, you warm up to a target rep max (10RM in week 1, 8RM in week 2, etc.) and record the weight you hit. Don't worry if you overshoot or undershoot the target reps by a couple — just record what you did and move to the drop sets.
+For the T1 first set each week, warm up to the target rep max (10RM in week 1, 8RM in week 2, etc.), stop with 1-2 clean reps in reserve, and record the weight you hit. Don't worry if you overshoot or undershoot the target — record what you did, adjust later work if needed, and move to the drop sets.
 
 ### Can I swap exercises in Jacked and Tan 2.0?
 
-Yes, especially T2b and T3 exercises. Pick movements that support your T1 lifts and address your weak points. T1 exercises should stay as the main competition lifts, and T2a exercises should remain close variations of your T1 movements.
+Yes, especially T2b and T3 exercises. Pick movements that support your T1 lifts and address your weak points. Keep T1 exercises as safe, heavily loadable compound movements and preserve the alternating lower/upper structure; T2a exercises should remain close variations of the relevant T1 movements.
 
 ```liftoscript
 # Week 1
 ## Day 1
-// **T1**. Warmup up to **10 RM** for the first set, then try a 10RM, tap the first
+// **T1**. Warm up to **10 RM** for the first set, then try a 10RM, tap the first
 // set and enter the 10RM weight you get. Then, do the drop sets (based on TM)
 t1 / used: none / 1x10 75%+ (10RM), 2x6 65% (TM 70%), 1x6+ 65% (TM 70%) / update: custom() {~
   if (week >= 7 && week <= 11 && setIndex == 1) {
     weights = completedWeights[1] * (week >= 10 ? 0.9 : 0.85)
   }
 ~} / progress: custom() {~
-  if (week == 6 || week == 12) {
+  if ((week == 6 || week == 12) && completedReps[1] >= reps[1]) {
     rm1 = completedWeights[1]
   }
 ~}
@@ -206,7 +208,7 @@ Overhead Press[1,1-12] / ...t1
 // ...t2a
 Incline Bench Press[2,1-5] / ...t2a
 // ...t2b
-Push Press[3,1-5] / ...t2b
+Push Press, Barbell[3,1-5] / ...t2b
 // ...t3
 Triceps Pushdown[4,1-6] / ...t3
 // ...t3
@@ -217,7 +219,7 @@ Incline Curl[4,1-6] / ...t3
 
 # Week 2
 ## Day 1
-// **T1**. Warmup up to **8 RM** for the first set, then try a 8RM, tap the first
+// **T1**. Warm up to **8 RM** for the first set, then try an 8RM, tap the first
 // set and enter the 8RM weight you get. Then, do the drop sets (based on TM)
 t1 / 1x8 80%+ (8RM), 2x5 70% (TM 75%), 1x5+ 70% (TM 75%)
 t2a / 4x8 60% (TM 60%)
@@ -239,7 +241,7 @@ t3 / 1x18 50%+ (18RM), 3x1+ 50% (MRS) / 60s
 
 # Week 3
 ## Day 1
-// **T1**. Warmup up to **6 RM** for the first set, then try a 6RM, tap the first
+// **T1**. Warm up to **6 RM** for the first set, then try a 6RM, tap the first
 // set and enter the 6RM weight you get. Then, do the drop sets (based on TM)
 t1 / 1x6 85%+ (6RM), 2x4 75% (TM 80%), 1x4+ 75% (TM 80%)
 t2a / 4x6 70% (TM 70%)
@@ -300,7 +302,7 @@ t3 / 1x12 70%+ (12RM), 3x1+ 70% (MRS) / 60s
 
 # Week 6
 ## Day 1
-// **T1**. Testing your 1RM! This set will update 1RM of this exercise.
+// **T1**. Work up to a conservative single you could confidently double. This set updates the exercise 1RM.
 t1 / 1x1 100%+ (1RM)
 // **T3.** Same as **T2b**, just 10RM
 t3 / 1x10 75%+ (10RM), 3x1+ 75% (MRS) / 60s
@@ -336,7 +338,7 @@ Lat Pulldown[3,7-10] / ...t2b
 
 ## Day 4
 Incline Bench Press[2,7-11] / ...t2a
-Push Press[3,7-10] / ...t2b
+Push Press, Barbell[3,7-10] / ...t2b
 
 
 # Week 8


### PR DESCRIPTION
## Summary

- align every T1, T2a, T2b, and T3 weekly prescription with Cody Lefever's official Jacked & Tan 2.0 guide
- restore the missing Week 11 T2a and T3 work while keeping T2b at rest
- model MRS as three unrestricted max-rep follow-on sets at the first set's weight, with the prescribed short rest
- clarify RM effort, movement-specific TMs, the conservative Week 6 single, mid-cycle max updates, tier rest weeks, intended audience, and program goals
- make the Week 6 set label distinguish its conservative single from Week 12's final 1RM test, and document how to respond to missed T2a volume
- resolve Push Press to the official barbell movement and prevent failed Week 6/12 singles from overwriting 1RM
- preserve the ask-weight prompt for every T1 RM after planner serialization, especially the Week 6 and Week 12 test singles

## Sources and decisions

Compared the Liftoscript against Cody's original guide, his GZCL applications guide, the author-linked GZCL Free Compendium, and the current Cody-partnered Boostcamp listing:

- https://swoleateveryheight.blogspot.com/2016/07/jacked-tan-20.html
- https://swoleateveryheight.blogspot.com/2016/02/gzcl-applications-adaptations.html
- https://www.dropbox.com/scl/fi/a840v1mjwg3t6ll/GZCL-Free-Compendium-July-4th-Update.xlsx?rlkey=9fapwvxrwualym7qrhwn5va1u&dl=0
- https://www.boostcamp.app/coaches/cody-lefever/jacked-tan-2-0

Also cross-checked the result against the Fitness Wiki's GZCL review archive and the strongest r/gzcl community references:

- https://thefitness.wiki/routines/strength-training-muscle-building/
- https://thefitness.wiki/intermediate-advanced-resources/program-review-archive/
- https://www.reddit.com/r/gzcl/wiki/index/
- https://www.reddit.com/r/gzcl/comments/89jsp6/guide_jacked_tan_20_jnt_20/
- https://www.reddit.com/r/gzcl/comments/wa1nz4/daily_thread_july_28_2022/
- https://www.reddit.com/r/weightroom/comments/7o3voq/program_review_jacked_tan_20/

The Fitness Wiki does not publish a separate J&T 2.0 prescription; it treats GZCL as adaptable and curates program reviews. The r/gzcl wiki and Cody-praised community guide corroborate the 12-week/four-day structure, everyday TM, 1-2 RIR, exercise counts, rest ranges, and RM-plus-three-MRS interpretation. A Wiki-linked review documents the common mistake of reading `3MRS` as three total sets; this implementation correctly programs the RM set plus three additional MRS.

The community guide has two illustrative T2a numbers that conflict with Cody's official post: Week 2 says 65% instead of 60%, and Week 4 says four sets instead of five. The direct official prescription and later r/gzcl weekly summaries agree with the current `4x8 60%` and `5x4 75%`, so those community examples do not override the primary sources.

The blog is internally inconsistent about the Block 2 T2b RM sequence. Its summary and the official workbook both specify 12/10/8/6 for Weeks 7-10, so the script uses that sequence.

Liftoscript percentages reference an exercise's 1RM rather than a separate TM. For T1 Weeks 1-5, the existing 65/70/75/77.5/80% values approximate Cody's 70/75/80/82.5/85% TM values by estimating a 2RM as 93.75% of true 1RM with Epley and rounding to 2.5-point increments. The routine labels the official TM percentages and explains this implementation assumption.

T2a uses literal TM percentages. The author workbook borrows a related main-lift TM for close variants such as close-grip bench and deficit deadlift, uses a separate TM for Front Squat, and provides an independent Incline Bench TM field. The workbook sample uses Incline as MRS work, but this Liftosaur variant selects it as T2a; the routine now tells users to put the appropriate TM or reference TM in each selected T2a exercise's 1RM field.

The original guide says novice-to-elite lifters can benefit while emphasizing intermediates; the current partnered listing recommends at least one year of experience. The catalog remains tagged for the primary intermediate audience, while the FAQ now states the nuance instead of categorically excluding newer lifters.

Cody calls Week 6 a "1RM" but defines it as a single the lifter could confidently double, and r/gzcl discussions show that users commonly mistake it for an all-out test. The workout now labels it `single`, retains Cody's exact effort guidance, and reserves `1RM` for Week 12. Cody's guide also says the final T2a set should always be completable and to reduce that movement's intensity after a miss; the routine now states this explicitly.

## Test plan

- [x] validate the Liftoscript with `scripts/validate_liftoscript.ts`
- [x] run `scripts/build-programs.ts` and `scripts/build-markdown.js`
- [x] run all 126 planner tests
- [x] evaluate all 12 weeks x 4 days (244 entries / 1,028 sets) against the official tier, set, rep, percentage, timer, and rest-week matrix in both lb and kg
- [x] simulate all 156 MRS first-set weight propagations and all 20 Week 7-11 T1 daily-RM backoffs
- [x] simulate successful, failed, skipped, and incomplete Week 6/12 singles; only completed singles update the correct exercise's 1RM
- [x] persist all 48 workouts sequentially and probe all future Week 6/12 test singles after every save (384 probes); ask-weight prompts and completed-weight updates survive every planner round trip
- [x] confirm Push Press resolves to `pushpress_barbell` and no state leaks across entries, days, or weeks
- [x] confirm only `programs/builtin/gzcl-jacked-and-tan-2.md` is modified
